### PR TITLE
Adding support for By.CssSelector in SpecBind.Selenium

### DIFF
--- a/src/SpecBind.Selenium.Tests/LocatorBuilderFixture.cs
+++ b/src/SpecBind.Selenium.Tests/LocatorBuilderFixture.cs
@@ -30,7 +30,22 @@ namespace SpecBind.Selenium.Tests
 
             Assert.AreEqual(1, resultList.Count);
             var item = resultList.First();
-            Assert.AreEqual(By.Id("MyId"), item);
+            Assert.AreEqual(By.Id("MyId"), item);            
+        }
+
+        /// <summary>
+        /// Tests the attribute with a CSS selector
+        /// </summary>
+        [TestMethod]
+        public void TestAttributeWithIdReturnsCssSelectorLocator()
+        {
+            var attribute = new ElementLocatorAttribute { CssSelector = "div#MyId" };
+
+            var resultList = LocatorBuilder.GetElementLocators(attribute);
+
+            Assert.AreEqual(1, resultList.Count);
+            var item = resultList.First();
+            Assert.AreEqual(By.CssSelector("div#MyId"), item);    
         }
 
         /// <summary>

--- a/src/SpecBind.Selenium/LocatorBuilder.cs
+++ b/src/SpecBind.Selenium/LocatorBuilder.cs
@@ -30,6 +30,7 @@ namespace SpecBind.Selenium
             SetProperty(locators, attribute, a => By.Name(a.Name), a => a.Name != null);
             SetProperty(locators, attribute, a => By.ClassName(a.Class), a => a.Class != null);
             SetProperty(locators, attribute, a => By.LinkText(a.Text), a => a.Text != null);
+            SetProperty(locators, attribute, a => By.CssSelector(a.CssSelector), a => a.CssSelector != null);
 
             var xpathTag = new XPathTag(attribute.NormalizedTagName);
 

--- a/src/SpecBind/Pages/ElementLocatorAttribute.cs
+++ b/src/SpecBind/Pages/ElementLocatorAttribute.cs
@@ -131,6 +131,12 @@ namespace SpecBind.Pages
 		/// <value>The value attribute.</value>
 		public string Value { get; set; }
 
-		#endregion
+        /// <summary>
+        /// Gets or sets the CSS selector to use
+        /// </summary>
+        /// <value>The CSS selector.</value>
+	    public string CssSelector { get; set; }
+
+	    #endregion
 	}
 }


### PR DESCRIPTION
Hi Dan,

I've added By.CssSelector for selenium. I usually use these over XPath queries for more complex tag structures.

I haven't done the CodedUI side, but I found this snippet and it looks like It'll fit right into PageBuilder.cs

http://social.msdn.microsoft.com/Forums/en-US/31dcf915-9c6b-4b5a-84c3-341cf780fc85/finding-htmlcontrols-by-css-selector-using-queryselectorall?forum=vsautotest
