### PR TITLE
Fixes #54 updating Selenium and making use of the new HideCommandPromptW...

### DIFF
--- a/src/SpecBind.Selenium.IntegrationTests/SpecBind.Selenium.IntegrationTests.csproj
+++ b/src/SpecBind.Selenium.IntegrationTests/SpecBind.Selenium.IntegrationTests.csproj
@@ -42,11 +42,13 @@
     <Reference Include="TechTalk.SpecFlow">
       <HintPath>..\packages\SpecFlow.1.9.0\lib\net35\TechTalk.SpecFlow.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver">
-      <HintPath>..\packages\Selenium.WebDriver.2.37.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Selenium.WebDriver.2.44.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support">
-      <HintPath>..\packages\Selenium.Support.2.37.0\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Selenium.Support.2.44.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/src/SpecBind.Selenium.IntegrationTests/packages.config
+++ b/src/SpecBind.Selenium.IntegrationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Selenium.Support" version="2.37.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.37.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="2.44.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.44.0" targetFramework="net45" />
   <package id="SpecFlow" version="1.9.0" targetFramework="net45" />
 </packages>

--- a/src/SpecBind.Selenium.Tests/SpecBind.Selenium.Tests.csproj
+++ b/src/SpecBind.Selenium.Tests/SpecBind.Selenium.Tests.csproj
@@ -43,13 +43,13 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.37.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="WebDriver, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Selenium.WebDriver.2.37.0\lib\net40\WebDriver.dll</HintPath>
+      <HintPath>..\packages\Selenium.WebDriver.2.44.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.37.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="WebDriver.Support, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Selenium.Support.2.37.0\lib\net40\WebDriver.Support.dll</HintPath>
+      <HintPath>..\packages\Selenium.Support.2.44.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/src/SpecBind.Selenium.Tests/packages.config
+++ b/src/SpecBind.Selenium.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
-  <package id="Selenium.Support" version="2.37.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.37.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="2.44.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.44.0" targetFramework="net45" />
 </packages>

--- a/src/SpecBind.Selenium/SeleniumBrowserFactory.cs
+++ b/src/SpecBind.Selenium/SeleniumBrowserFactory.cs
@@ -70,22 +70,29 @@ namespace SpecBind.Selenium
                 {
                     case BrowserType.IE:
                         var explorerOptions = new InternetExplorerOptions { EnsureCleanSession = browserFactoryConfiguration.EnsureCleanSession };
-                        driver = new InternetExplorerDriver(explorerOptions);
+                        var internetExplorerDriverService = InternetExplorerDriverService.CreateDefaultService();
+                        internetExplorerDriverService.HideCommandPromptWindow = true;
+                        driver = new InternetExplorerDriver(internetExplorerDriverService, explorerOptions);
                         break;
                     case BrowserType.FireFox:
                         driver = GetFireFoxDriver(browserFactoryConfiguration);
                         break;
                     case BrowserType.Chrome:
                         var chromeOptions = new ChromeOptions { LeaveBrowserRunning = false };
+                        var chromeDriverService = ChromeDriverService.CreateDefaultService();
+                        chromeDriverService.HideCommandPromptWindow = true;
+
                         if (browserFactoryConfiguration.EnsureCleanSession)
                         {
                             chromeOptions.AddArgument("--incognito");
                         }
 
-                        driver = new ChromeDriver();
+                        driver = new ChromeDriver(chromeDriverService, chromeOptions);
                         break;
                     case BrowserType.PhantomJS:
-                        driver = new PhantomJSDriver();
+                        var phantomJsDriverService = PhantomJSDriverService.CreateDefaultService();
+                        phantomJsDriverService.HideCommandPromptWindow = true;
+                        driver = new PhantomJSDriver(phantomJsDriverService);
                         break;
                     case BrowserType.Safari:
                         driver = new SafariDriver();

--- a/src/SpecBind.Selenium/SpecBind.Selenium.csproj
+++ b/src/SpecBind.Selenium/SpecBind.Selenium.csproj
@@ -44,11 +44,13 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver">
-      <HintPath>..\packages\Selenium.WebDriver.2.37.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Selenium.WebDriver.2.44.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support">
-      <HintPath>..\packages\Selenium.Support.2.37.0\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Selenium.Support.2.44.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SpecBind.Selenium/packages.config
+++ b/src/SpecBind.Selenium/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Selenium.Support" version="2.37.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.37.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="2.44.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.44.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
...indow property to avoid showing the command windows used by the drivers for ie, chrome and phantomjs based on http://yizeng.me/2014/03/05/hide-command-prompt-window-in-selenium-webdriver-net-binding/
