### PR TITLE
Support token substitution in page navigation

### DIFF
--- a/src/SpecBind.Tests/PageNavigationStepsFixture.cs
+++ b/src/SpecBind.Tests/PageNavigationStepsFixture.cs
@@ -40,8 +40,10 @@ namespace SpecBind.Tests
 
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue(testPage.Object, PageStepBase.CurrentPageKey));
+            
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             steps.GivenNavigateToPageStep("mypage");
 
@@ -69,7 +71,9 @@ namespace SpecBind.Tests
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue(It.IsAny<IPage>(), PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             var table = new Table("Id", "Part");
             table.AddRow("1", "A");
@@ -97,7 +101,9 @@ namespace SpecBind.Tests
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue(testPage.Object, PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             steps.GivenEnsureOnPageStep("mypage");
 
@@ -129,7 +135,9 @@ namespace SpecBind.Tests
             scenarioContext.Setup(s => s.GetValue<IPage>(PageStepBase.CurrentPageKey)).Returns(page.Object);
             scenarioContext.Setup(s => s.SetValue(listItem.Object, PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             steps.GivenEnsureOnDialogStep("my property");
 
@@ -156,7 +164,9 @@ namespace SpecBind.Tests
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue(testPage.Object, PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             steps.WaitForPageStep("mypage");
 
@@ -185,7 +195,9 @@ namespace SpecBind.Tests
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue<IPage>(null, PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             ExceptionHelper.SetupForException<PageNavigationException>(() => steps.WaitForPageStep("mypage"),
                 e =>
@@ -217,7 +229,9 @@ namespace SpecBind.Tests
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue(testPage.Object, PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             steps.WaitForPageStepWithTimeout(10, "mypage");
 
@@ -247,7 +261,9 @@ namespace SpecBind.Tests
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.SetValue(testPage.Object, PageStepBase.CurrentPageKey));
 
-            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object);
+            var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+
+            var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 
             steps.WaitForPageStepWithTimeout(0, "mypage");
 

--- a/src/SpecBind.Tests/PageNavigationStepsFixture.cs
+++ b/src/SpecBind.Tests/PageNavigationStepsFixture.cs
@@ -72,6 +72,7 @@ namespace SpecBind.Tests
             scenarioContext.Setup(s => s.SetValue(It.IsAny<IPage>(), PageStepBase.CurrentPageKey));
 
             var tokenManager = new Mock<ITokenManager>(MockBehavior.Strict);
+            tokenManager.Setup(t => t.GetToken(It.IsAny<string>())).Returns<string>(s => s);
 
             var steps = new PageNavigationSteps(scenarioContext.Object, pipelineService.Object, tokenManager.Object);
 

--- a/src/SpecBind/PageNavigationSteps.cs
+++ b/src/SpecBind/PageNavigationSteps.cs
@@ -38,19 +38,22 @@ namespace SpecBind
         private const string GivenWaitForPageWithTimeoutStepRegex = @"I waited (\d+) seconds? for the (.+) page";
 		
 	    private readonly IActionPipelineService actionPipelineService;
+	    private readonly ITokenManager tokenManager;
 
 	    /// <summary>
 	    /// Initializes a new instance of the <see cref="PageNavigationSteps" /> class.
 	    /// </summary>
 	    /// <param name="scenarioContext">The scenario context.</param>
 	    /// <param name="actionPipelineService">The action pipeline service.</param>
-	    public PageNavigationSteps(IScenarioContextHelper scenarioContext, IActionPipelineService actionPipelineService)
+        /// <param name="tokenManager">The token manager.</param>
+	    public PageNavigationSteps(IScenarioContextHelper scenarioContext, IActionPipelineService actionPipelineService, ITokenManager tokenManager)
             : base(scenarioContext)
-		{
-			this.actionPipelineService = actionPipelineService;
-		}
+	    {
+	        this.actionPipelineService = actionPipelineService;
+	        this.tokenManager = tokenManager;
+	    }
 
-		/// <summary>
+	    /// <summary>
 		/// A Given step for ensuring the browser is on the page with the specified name.
 		/// </summary>
 		/// <param name="pageName">The page name.</param>
@@ -113,7 +116,8 @@ namespace SpecBind
 				var row = pageArguments.Rows[0];
 				foreach (var header in pageArguments.Header.Where(h => !args.ContainsKey(h)))
 				{
-					args.Add(header, row[header]);
+				    var value = this.tokenManager.GetToken(row[header]);
+				    args.Add(header, value);
 				}
 			}
 


### PR DESCRIPTION
Hello Dan

My name is Dave Winchurch and I work with Krister Bone. We use SpecBind extensively in all our acceptance tests. It really helps prevent the standard sprawl of custom bindings you traditionally get with SpecFlow. It's a great tool and I'm please to have been introduced to it!

We created a scenario where we find and store an id for a vacancy, apply for that vacancy then return to its page to verify some markup. There was an expectation that we could substitute this id in the PageNavigation.UrlTemplate property for a page, in this case:

```
//Set token
 _tokenManager.SetToken("VacancyId", vacancyId);

//Page attributes
[PageNavigation("/apprenticeship/[0-9]+", UrlTemplate = "/apprenticeship/{VacancyId}")]

//Scenario
And I navigate to the ApprenticeshipDetailsPage page with parameters
		| VacancyId   |
		| {VacancyId} |
```

However this simply replaced "/apprenticeship/{VacancyId}" with "/apprenticeship/{VacancyId}"

This pull request contains the small change I made to support this usage. It passes the tokenManager down a bit further in the stack and relies on the tokenManager.GetToken method's behavior of returning the original string if a value is not found for that key to maintain previous functionality.

This is actually my first ever pull request so please accept my apologies if I've done this wrong! I'd also welcome any comments or criticism if the code isn't up to your standards. I'm of course happy to make any changes you request. I'd quite like to contribute more to this project if possible.

Thanks for your time.

Dave