### PR TITLE
Updating Selenuim version requirement for HideCommandPromptWindow

### DIFF
--- a/src/SpecBind.Selenium/SpecBind.Selenium.nuspec
+++ b/src/SpecBind.Selenium/SpecBind.Selenium.nuspec
@@ -16,8 +16,8 @@
     <dependencies>
       <group targetFramework=".NETFramework4.5">
         <dependency id="SpecBind" version="$version$" />
-        <dependency id="Selenium.WebDriver" version="2.37.0" />
-        <dependency id="Selenium.Support" version="2.37.0" />
+        <dependency id="Selenium.WebDriver" version="2.44.0" />
+        <dependency id="Selenium.Support" version="2.44.0" />
         <dependency id="SpecBindGeneratorPlugin.SpecFlow" version="$version$" />
       </group>
     </dependencies>


### PR DESCRIPTION
Commit bbcc2a0848774f6c76bed8c76a2c248332aefef8 from last year made use of the new Selenium HideCommandPromptWindow property. This requires version 2.44.0 of the Selenium Support and WebDriver nuget packages. This wasn't specified and so when creating a new project, I couldn't run any tests until I manually updated the packages.

This change makes the requirement explicit.