### PR TITLE
Adding Excluded Assemblies configuration setting

### DIFF
--- a/src/SpecBind.Plugin/SpecBind.Plugin.csproj
+++ b/src/SpecBind.Plugin/SpecBind.Plugin.csproj
@@ -51,6 +51,12 @@
     <Compile Include="..\SpecBind\Configuration\ApplicationConfigurationElement.cs">
       <Link>Configuration\ApplicationConfigurationElement.cs</Link>
     </Compile>
+    <Compile Include="..\SpecBind\Configuration\AssemblyCollection.cs">
+      <Link>Configuration\AssemblyCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\SpecBind\Configuration\AssemblyElement.cs">
+      <Link>Configuration\AssemblyElement.cs</Link>
+    </Compile>
     <Compile Include="..\SpecBind\Configuration\BrowserFactoryConfigurationElement.cs">
       <Link>Configuration\BrowserFactoryConfigurationElement.cs</Link>
     </Compile>

--- a/src/SpecBind.Tests/ConfigurationFixture.cs
+++ b/src/SpecBind.Tests/ConfigurationFixture.cs
@@ -5,6 +5,8 @@
 namespace SpecBind.Tests
 {
     using System;
+    using System.Configuration;
+    using System.Linq;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -48,6 +50,20 @@ namespace SpecBind.Tests
             Assert.AreEqual(TimeSpan.FromSeconds(15), section.BrowserFactory.PageLoadTimeout);
             Assert.AreEqual(true, section.BrowserFactory.EnsureCleanSession);
             Assert.IsNotNull(section.BrowserFactory.Settings);
+            Assert.AreEqual(0, section.Application.ExcludedAssemblies.Cast<AssemblyElement>().ToList().Count);
+        }
+
+        [TestMethod]
+        public void TestLoadingExcludedAssemblies()
+        {
+            var fileMap = new ConfigurationFileMap("WithExcludedAssemblyConfig.config");
+            var config = ConfigurationManager.OpenMappedMachineConfiguration(fileMap);
+            var section = config.GetSection("specBind") as ConfigurationSectionHandler;
+
+            Assert.IsNotNull(section);
+            var assemblies = section.Application.ExcludedAssemblies.Cast<AssemblyElement>().ToList();
+            Assert.AreEqual(1, assemblies.Count);
+            Assert.AreEqual("MyCoolApp, Version=1.2.3.0, Culture=neutral, PublicKeyToken=null", assemblies[0].Name);
         }
     }
 }

--- a/src/SpecBind.Tests/ConfigurationFixture.cs
+++ b/src/SpecBind.Tests/ConfigurationFixture.cs
@@ -53,6 +53,9 @@ namespace SpecBind.Tests
             Assert.AreEqual(0, section.Application.ExcludedAssemblies.Cast<AssemblyElement>().ToList().Count);
         }
 
+        /// <summary>
+        /// Tests that the ExcludedAssemblies property is populated if it is in the config file.
+        /// </summary>
         [TestMethod]
         public void TestLoadingExcludedAssemblies()
         {

--- a/src/SpecBind.Tests/SpecBind.Tests.csproj
+++ b/src/SpecBind.Tests/SpecBind.Tests.csproj
@@ -135,6 +135,9 @@
     <Compile Include="UriHelperFixture.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="WithExcludedAssemblyConfig.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/SpecBind.Tests/WithExcludedAssemblyConfig.config
+++ b/src/SpecBind.Tests/WithExcludedAssemblyConfig.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="specBind" type="SpecBind.Configuration.ConfigurationSectionHandler, SpecBind"/>
+  </configSections>
+  <specBind>
+    <application startUrl="http://localhost:2222">
+      <excludedAssemblies>
+        <add name="MyCoolApp, Version=1.2.3.0, Culture=neutral, PublicKeyToken=null" />
+      </excludedAssemblies>
+    </application>
+    <browserFactory provider="SpecBind.Tests.Support.MockBrowserFactory, SpecBind.Tests" browserType="IE"/>
+  </specBind>
+</configuration>

--- a/src/SpecBind/ActionPipeline/ActionRepository.cs
+++ b/src/SpecBind/ActionPipeline/ActionRepository.cs
@@ -10,6 +10,8 @@ namespace SpecBind.ActionPipeline
 
     using BoDi;
 
+    using SpecBind.Configuration;
+    using SpecBind.Helpers;
     using SpecBind.Validation;
 
     /// <summary>
@@ -90,8 +92,10 @@ namespace SpecBind.ActionPipeline
         /// </summary>
 	    public void Initialize()
         {
+            var configSection = SettingHelper.GetConfigurationSection();
+            var excludedAssemblies = configSection.Application.ExcludedAssemblies.Cast<AssemblyElement>().Select(a => a.Name);
             // Get all items from the current assemblies
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic && !a.GlobalAssemblyCache);
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic && !a.GlobalAssemblyCache && !excludedAssemblies.Contains(a.FullName));
             foreach (var asmType in assemblies.SelectMany(a => a.GetExportedTypes()).Where(t => !t.IsAbstract && !t.IsInterface))
             {
                 this.RegisterType(asmType);

--- a/src/SpecBind/Configuration/ApplicationConfigurationElement.cs
+++ b/src/SpecBind/Configuration/ApplicationConfigurationElement.cs
@@ -11,6 +11,7 @@ namespace SpecBind.Configuration
 	public class ApplicationConfigurationElement : ConfigurationElement
 	{
 		private const string StartUrlElement = @"startUrl";
+		private const string ExcludedAssembliesElement = @"excludedAssemblies";
 
 		/// <summary>
 		/// Gets or sets the application's start URL setting.
@@ -28,6 +29,17 @@ namespace SpecBind.Configuration
 			{
 				this[StartUrlElement] = value;
 			}
+		}
+
+		/// <summary>
+		/// Gets the list of excluded assemblies, if any are supplied.
+		/// </summary>
+		/// <value>The list of excluded assemblies.</value>
+		[ConfigurationProperty(ExcludedAssembliesElement, IsRequired = false)]
+		[ConfigurationCollection(typeof(AssemblyElement))]
+		public AssemblyCollection ExcludedAssemblies
+		{
+			get { return (AssemblyCollection)base[ExcludedAssembliesElement]; }
 		}
 	}
 }

--- a/src/SpecBind/Configuration/AssemblyCollection.cs
+++ b/src/SpecBind/Configuration/AssemblyCollection.cs
@@ -1,4 +1,7 @@
-﻿namespace SpecBind.Configuration
+﻿// <copyright file="AssemblyCollection.cs">
+//    Copyright © 2015 Dan Piessens.  All rights reserved.
+// </copyright>
+namespace SpecBind.Configuration
 {
 	using System.Collections.Generic;
 	using System.Configuration;
@@ -10,6 +13,12 @@
 	{
 		private readonly List<AssemblyElement> assemblies = new List<AssemblyElement>();
 
+		/// <summary>
+		/// When overridden in a derived class, creates a new <see cref="T:System.Configuration.ConfigurationElement"/>.
+		/// </summary>
+		/// <returns>
+		/// A new <see cref="T:System.Configuration.ConfigurationElement"/>.
+		/// </returns>
 		protected override ConfigurationElement CreateNewElement()
 		{
 			var newAssembly = new AssemblyElement();
@@ -17,6 +26,13 @@
 			return newAssembly;
 		}
 
+		/// <summary>
+		/// Gets the element key for a specified configuration element when overridden in a derived class.
+		/// </summary>
+		/// <returns>
+		/// An <see cref="T:System.Object"/> that acts as the key for the specified <see cref="T:System.Configuration.ConfigurationElement"/>.
+		/// </returns>
+		/// <param name="element">The <see cref="T:System.Configuration.ConfigurationElement"/> to return the key for. </param>
 		protected override object GetElementKey(ConfigurationElement element)
 		{
 			return this.assemblies.Find(a => a.Equals(element));

--- a/src/SpecBind/Configuration/AssemblyCollection.cs
+++ b/src/SpecBind/Configuration/AssemblyCollection.cs
@@ -1,0 +1,25 @@
+﻿namespace SpecBind.Configuration
+{
+	using System.Collections.Generic;
+	using System.Configuration;
+
+	/// <summary>
+	/// Configuration collection for holding assembly information.
+	/// </summary>
+	public class AssemblyCollection : ConfigurationElementCollection
+	{
+		private readonly List<AssemblyElement> assemblies = new List<AssemblyElement>();
+
+		protected override ConfigurationElement CreateNewElement()
+		{
+			var newAssembly = new AssemblyElement();
+			this.assemblies.Add(newAssembly);
+			return newAssembly;
+		}
+
+		protected override object GetElementKey(ConfigurationElement element)
+		{
+			return this.assemblies.Find(a => a.Equals(element));
+		}
+	}
+}

--- a/src/SpecBind/Configuration/AssemblyElement.cs
+++ b/src/SpecBind/Configuration/AssemblyElement.cs
@@ -1,4 +1,7 @@
-﻿namespace SpecBind.Configuration
+﻿// <copyright file="AssemblyElement.cs">
+//    Copyright © 2015 Dan Piessens.  All rights reserved.
+// </copyright>
+namespace SpecBind.Configuration
 {
 	using System.Configuration;
 
@@ -20,6 +23,7 @@
 			{
 				return (string)this[NameKey];
 			}
+
 			set
 			{
 				this[NameKey] = value;

--- a/src/SpecBind/Configuration/AssemblyElement.cs
+++ b/src/SpecBind/Configuration/AssemblyElement.cs
@@ -1,0 +1,29 @@
+﻿namespace SpecBind.Configuration
+{
+	using System.Configuration;
+
+	/// <summary>
+	/// The configuration element that handles an assembly configuration element.
+	/// </summary>
+	public class AssemblyElement : ConfigurationElement
+	{
+		private const string NameKey = @"name";
+
+		/// <summary>
+		/// Gets or sets the assembly's name.
+		/// </summary>
+		/// <value>The assembly's name.</value>
+		[ConfigurationProperty(NameKey, IsRequired = true)]
+		public string Name
+		{
+			get
+			{
+				return (string)this[NameKey];
+			}
+			set
+			{
+				this[NameKey] = value;
+			}
+		}
+	}
+}

--- a/src/SpecBind/SpecBind.csproj
+++ b/src/SpecBind/SpecBind.csproj
@@ -91,6 +91,8 @@
     <Compile Include="BrowserSupport\IBrowser.cs" />
     <Compile Include="BrowserSupport\NullLogger.cs" />
     <Compile Include="Configuration\ApplicationConfigurationElement.cs" />
+    <Compile Include="Configuration\AssemblyCollection.cs" />
+    <Compile Include="Configuration\AssemblyElement.cs" />
     <Compile Include="Configuration\BrowserFactoryConfigurationElement.cs" />
     <Compile Include="Configuration\ConfigurationSectionHandler.cs" />
     <Compile Include="ActionPipeline\ActionPipelineService.cs" />


### PR DESCRIPTION
Added an optional app.config configuration setting to list out any
assemblies you don't want to scan when building the ActionRepository.