### PR TITLE
Bug fix for PageNavigation with template and absolute uri

### DIFF
--- a/src/SpecBind.Tests/UriHelperFixture.cs
+++ b/src/SpecBind.Tests/UriHelperFixture.cs
@@ -286,7 +286,25 @@ namespace SpecBind.Tests
 			browser.VerifyAll();
 		}
 
+		/// <summary>
+		///     Tests the FillPageUri method when a template is specified and AbsoluteUri is true.
+		///     When these conditions are met, the base Uri should be ignored.
+		/// </summary>
+		[TestMethod]
+		public void TestFillPageUriWithTemplateAndAbsoluteUri()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
 
+			// Setting base uri here should not matter as it will get ignored since AbsoluteUri = true for this test
+			UriHelper.BaseUri = new Uri("http://localhost:2222/");
+			
+			var url = UriHelper.FillPageUri(
+				browser.Object, typeof(NavigationWithTemplateAndAbsoluteUri), new Dictionary<string, string> { { "param", "1" } });
+
+			Assert.AreEqual("http://root?q=1", url);
+
+			browser.VerifyAll();
+		}
 
 
         // ReSharper disable ClassNeverInstantiated.Local
@@ -303,6 +321,11 @@ namespace SpecBind.Tests
 		/// </summary>
 		[PageNavigation("/root", UrlTemplate = "/root/{id}")]
 		private class NavigationAttributePage : TestBase
+		{
+		}
+
+		[PageNavigation("http://root", UrlTemplate = "http://root?q={param}", IsAbsoluteUrl = true)]
+		private class NavigationWithTemplateAndAbsoluteUri : TestBase
 		{
 		}
 

--- a/src/SpecBind/Helpers/UriHelper.cs
+++ b/src/SpecBind/Helpers/UriHelper.cs
@@ -118,7 +118,7 @@ namespace SpecBind.Helpers
 		                return pageArguments.ContainsKey(groupName) ? pageArguments[groupName] : m.Value;
 		            });
 
-		    return CreateCompleteUri(new UriStructure(filledPage, false), false);
+		    return CreateCompleteUri(new UriStructure(filledPage, uriStructure.IsAbsolute), false);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This is a bug fix for when the PageNavigation attribute is being used
with a template and absolute uri is set to true. The navigation should
go to your specified url, but prior to this fix, would still preappend
the base root onto the absolute uri because the absolute uri property
was getting ignored.

I would see a url such as "http://baseurl/http://different-absolute-uri?q=param1" when it should have been "http://different-absolute-uri?q=param1"