### PR TITLE
Added StaleElementReferenceException catch clause

### DIFF
--- a/src/SpecBind.Selenium.Tests/SeleniumPageFixture.cs
+++ b/src/SpecBind.Selenium.Tests/SeleniumPageFixture.cs
@@ -247,6 +247,22 @@ namespace SpecBind.Selenium.Tests
             element.VerifyAll();
         }
 
+
+        [TestMethod]
+        public void TestElementEnabledCheckWhenStaleElementReferenceReturnsFalse()
+        {
+            var element = new Mock<IWebElement>(MockBehavior.Strict);
+            element.SetupGet(e => e.Displayed).Throws<StaleElementReferenceException>();
+
+            var nativePage = new NativePage();
+            var page = new SeleniumPage(nativePage);
+
+            var result = page.ElementEnabledCheck(element.Object);
+
+            Assert.IsFalse(result);
+            element.VerifyAll();
+        }
+        
         /// <summary>
         /// Tests the get element text method when the control is a standard control.
         /// </summary>

--- a/src/SpecBind.Selenium/SeleniumPage.cs
+++ b/src/SpecBind.Selenium/SeleniumPage.cs
@@ -200,6 +200,10 @@ namespace SpecBind.Selenium
             {
                 return false;
             }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Added the StaleElementReferenceException catch clause referenced in
issue #74 (https://github.com/dpiessens/specbind/issues/74)