### PR TITLE
WaitForAngular and WaitForjQuery support

### DIFF
--- a/src/SpecBind.CodedUI/CodedUIBrowser.cs
+++ b/src/SpecBind.CodedUI/CodedUIBrowser.cs
@@ -3,26 +3,26 @@
 // </copyright>
 namespace SpecBind.CodedUI
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Drawing.Imaging;
-    using System.IO;
-    using System.Linq;
+	using System;
+	using System.Collections.Generic;
+	using System.Drawing.Imaging;
+	using System.IO;
+	using System.Linq;
 
-    using Microsoft.VisualStudio.TestTools.UITest.Extension;
-    using Microsoft.VisualStudio.TestTools.UITesting;
-    using Microsoft.VisualStudio.TestTools.UITesting.HtmlControls;
+	using Microsoft.VisualStudio.TestTools.UITest.Extension;
+	using Microsoft.VisualStudio.TestTools.UITesting;
+	using Microsoft.VisualStudio.TestTools.UITesting.HtmlControls;
 
-    using SpecBind.Actions;
-    using SpecBind.BrowserSupport;
-    using SpecBind.Helpers;
-    using SpecBind.Pages;
+	using SpecBind.Actions;
+	using SpecBind.BrowserSupport;
+	using SpecBind.Helpers;
+	using SpecBind.Pages;
 
-    /// <summary>
-    /// An IBrowser implementation for Coded UI.
-    /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public class CodedUIBrowser : BrowserBase
+	/// <summary>
+	/// An IBrowser implementation for Coded UI.
+	/// </summary>
+	// ReSharper disable once InconsistentNaming
+	public class CodedUIBrowser : BrowserBase
     {
         private readonly Dictionary<Type, Func<UITestControl, IBrowser, Action<HtmlControl>, HtmlDocument>> pageCache;
         private readonly Lazy<Dictionary<string, Func<UITestControl, HtmlFrame>>> frameCache;
@@ -104,6 +104,14 @@ namespace SpecBind.CodedUI
         }
 
         /// <summary>
+		/// Clears the URL.
+		/// </summary>
+		public override void ClearUrl()
+		{
+			this.GoTo(new Uri("about:blank"));
+		}
+
+		/// <summary>
         /// Closes this instance.
         /// </summary>
         public override void Close()
@@ -231,14 +239,20 @@ namespace SpecBind.CodedUI
             }
         }
 
-        /// <summary>
-        /// Releases windows and driver specific resources. This method is already protected by the base instance.
-        /// </summary>
-        protected override void DisposeWindow()
+		/// <summary>
+		/// Releases windows and driver specific resources. This method is already protected by the base instance.
+		/// </summary>
+		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+		protected override void DisposeWindow(bool disposing)
         {
+			if (this.IsDisposed)
+			{
+				return;
+			}
+
             if (this.window.IsValueCreated)
             {
-                this.window.Value.Dispose();
+				this.window.Value.Dispose();
             }
         }
 
@@ -324,7 +338,7 @@ namespace SpecBind.CodedUI
                         pageType.Name);
                 }
 
-
+                
             }
 
             var documentElement = function(parentElement, this, null);

--- a/src/SpecBind.Selenium.IntegrationTests/Features/ListTests.feature
+++ b/src/SpecBind.Selenium.IntegrationTests/Features/ListTests.feature
@@ -37,7 +37,7 @@ Scenario: Long Lists By Criteria
 
 Scenario: Verifying List Count
 	Given I navigated to the Student Courses page
-	Then I see Student Courses list contains 8 items
+	Then I see Student Courses list contains exactly 8 items
 
 Scenario: Selecting Items By Index
 	Given I navigated to the Student Courses page

--- a/src/SpecBind.Selenium.IntegrationTests/Features/ListTests.feature.cs
+++ b/src/SpecBind.Selenium.IntegrationTests/Features/ListTests.feature.cs
@@ -211,7 +211,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 39
  testRunner.Given("I navigated to the Student Courses page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line 40
- testRunner.Then("I see Student Courses list contains 8 items", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("I see Student Courses list contains exactly 8 items", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/SpecBind.Selenium.Tests/SeleniumBrowserFixture.cs
+++ b/src/SpecBind.Selenium.Tests/SeleniumBrowserFixture.cs
@@ -32,102 +32,89 @@ namespace SpecBind.Selenium.Tests
 	/// and then after that, we verify the driver.
 	/// </remarks>
 	[TestClass]
-    [ExcludeFromCodeCoverage]
-    public class SeleniumBrowserFixture
-    {
-        /// <summary>
-        /// Tests the getting of the page base type, expecting it to return null.
-        /// </summary>
-        [TestMethod]
-        public void TestGetPageBaseTypeReturnsNull()
-        {
+	[ExcludeFromCodeCoverage]
+	public class SeleniumBrowserFixture
+	{
+		/// <summary>
+		/// Tests the getting of the page base type, expecting it to return null.
+		/// </summary>
+		[TestMethod]
+		public void TestGetPageBaseTypeReturnsNull()
+		{
 			var driver = this.CreateMockWebDriverNotExpectingInitialization();
-			var logger = new Mock<ILogger>(MockBehavior.Loose);
 
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				var result = browser.BasePageType;
 				Assert.IsNull(result);
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the getting of the Url property returns the value from the window.
-        /// </summary>
-        [TestMethod]
-        public void TestGetUrlReturnsBrowserUrl()
-        {
-            const string BrowserUrl = "http://www.mysite.com/home";
+		/// <summary>
+		/// Tests the getting of the Url property returns the value from the window.
+		/// </summary>
+		[TestMethod]
+		public void TestGetUrlReturnsBrowserUrl()
+		{
+			const string BrowserUrl = "http://www.mysite.com/home";
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.SetupGet(d => d.Url).Returns(BrowserUrl);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				var result = browser.Url;
 				Assert.AreEqual(BrowserUrl, result);
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
+		/// <summary>
+		/// Tests the getting of the goto page calls the appropriate driver method.
+		/// </summary>
+		[TestMethod]
+		public void TestGotoPageCallsDriverMethod()
+		{
+			var url = new Uri("http://www.bing.com");
 
-        /// <summary>
-        /// Tests the getting of the goto page calls the appropriate driver method.
-        /// </summary>
-        [TestMethod]
-        public void TestGotoPageCallsDriverMethod()
-        {
-            var url = new Uri("http://www.bing.com");
-
-            var navigation = new Mock<INavigation>(MockBehavior.Strict);
-            navigation.Setup(n => n.GoToUrl(url));
+			var navigation = new Mock<INavigation>(MockBehavior.Strict);
+			navigation.Setup(n => n.GoToUrl(url));
 
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.Navigate()).Returns(navigation.Object);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.GoTo(url);
-			}
+			});
 
-            driver.VerifyAll();
-            navigation.VerifyAll();
-        }
+			navigation.VerifyAll();
+		}
 
-        /// <summary>
-        /// Tests the add cookie calls driver method.
-        /// </summary>
-        [TestMethod]
-        public void TestAddCookieWhenCookieDoesntExistCallsDriverMethod()
-        {
-            var expireDate = DateTime.Now;
+		/// <summary>
+		/// Tests the add cookie calls driver method.
+		/// </summary>
+		[TestMethod]
+		public void TestAddCookieWhenCookieDoesntExistCallsDriverMethod()
+		{
+			var expireDate = DateTime.Now;
 
-            var cookies = new Mock<ICookieJar>(MockBehavior.Strict);
-            cookies.Setup(c => c.GetCookieNamed("TestCookie")).Returns((Cookie)null);
-            cookies.Setup(c => c.AddCookie(It.Is<Cookie>(ck => ck.Name == "TestCookie" && ck.Value == "TestValue" && ck.Path == "/" && ck.Expiry == expireDate)));
+			var cookies = new Mock<ICookieJar>(MockBehavior.Strict);
+			cookies.Setup(c => c.GetCookieNamed("TestCookie")).Returns((Cookie)null);
+			cookies.Setup(c => c.AddCookie(It.Is<Cookie>(ck => ck.Name == "TestCookie" && ck.Value == "TestValue" && ck.Path == "/" && ck.Expiry == expireDate)));
 
-            var options = new Mock<IOptions>(MockBehavior.Strict);
-            options.Setup(o => o.Cookies).Returns(cookies.Object);
+			var options = new Mock<IOptions>(MockBehavior.Strict);
+			options.Setup(o => o.Cookies).Returns(cookies.Object);
 
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.Manage()).Returns(options.Object);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.AddCookie("TestCookie", "TestValue", "/", expireDate, null, false);
-			}
+			});
 
-            driver.VerifyAll();
-            options.VerifyAll();
-            cookies.VerifyAll();
-        }
+			options.VerifyAll();
+			cookies.VerifyAll();
+		}
 
 		/// <summary>
 		/// Tests the add cookie calls driver method.
@@ -148,404 +135,350 @@ namespace SpecBind.Selenium.Tests
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.Manage()).Returns(options.Object);
 
-			var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.AddCookie("TestCookie", "TestValue", "/", expireDate, null, false);
-			}
+			});
 
-            driver.VerifyAll();
-            options.VerifyAll();
-            cookies.VerifyAll();
-        }
+			options.VerifyAll();
+			cookies.VerifyAll();
+		}
 
-        /// <summary>
-        /// Tests the clear cookies method.
-        /// </summary>
-        [TestMethod]
-        public void TestClearCookies()
-        {
-            var cookies = new Mock<ICookieJar>(MockBehavior.Strict);
-            cookies.Setup(c => c.DeleteAllCookies());
+		/// <summary>
+		/// Tests the clear cookies method.
+		/// </summary>
+		[TestMethod]
+		public void TestClearCookies()
+		{
+			var cookies = new Mock<ICookieJar>(MockBehavior.Strict);
+			cookies.Setup(c => c.DeleteAllCookies());
 
-            var options = new Mock<IOptions>(MockBehavior.Strict);
-            options.Setup(o => o.Cookies).Returns(cookies.Object);
+			var options = new Mock<IOptions>(MockBehavior.Strict);
+			options.Setup(o => o.Cookies).Returns(cookies.Object);
 
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.Manage()).Returns(options.Object);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.ClearCookies();
-			}
+			});
 
-            driver.VerifyAll();
-            options.VerifyAll();
-            cookies.VerifyAll();
-        }
+			options.VerifyAll();
+			cookies.VerifyAll();
+		}
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when ok is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenOkIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.Ok, true);
-        }
+		/// <summary>
+		/// Tests the clear URL method.
+		/// </summary>
+		[TestMethod]
+		public void TestClearUrl()
+		{
+			var expected = "about:blank";
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when yes is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenYesIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.Yes, true);
-        }
+			var driver = this.CreateMockWebDriverExpectingInitialization();
+			driver.SetupSet(d => d.Url = expected);
+			driver.SetupGet(d => d.Url).Returns(expected);
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when retry is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenRetryIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.Retry, true);
-        }
+			this.TestBrowserWith(driver, browser =>
+			{
+				browser.ClearUrl();
+				var actual = browser.Url;
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when cancel is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenCancelIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.Cancel, false);
-        }
+				Assert.AreEqual(expected, actual);
+			});
+		}
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when close is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenCloseIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.Close, false);
-        }
+		/// <summary>
+		/// Tests the dismiss alert calls accept when ok is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenOkIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.Ok, true);
+		}
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when ignore is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenIgnoreIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.Ignore, false);
-        }
+		/// <summary>
+		/// Tests the dismiss alert calls accept when yes is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenYesIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.Yes, true);
+		}
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when no is chosen.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertAcceptsWhenNoIsChoosen()
-        {
-            TestAlertScenario(AlertBoxAction.No, false);
-        }
+		/// <summary>
+		/// Tests the dismiss alert calls accept when retry is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenRetryIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.Retry, true);
+		}
 
-        /// <summary>
-        /// Tests the dismiss alert calls accept when ok is chosen after entering text.
-        /// </summary>
-        [TestMethod]
-        public void TestDismissAlertEntersTextAndAcceptsWhenOkIsChoosen()
-        {
-            var alerter = new Mock<IAlert>(MockBehavior.Strict);
-            alerter.Setup(a => a.SendKeys("My Text"));
-            alerter.Setup(a => a.Accept());
+		/// <summary>
+		/// Tests the dismiss alert calls accept when cancel is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenCancelIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.Cancel, false);
+		}
 
-            var locator = new Mock<ITargetLocator>(MockBehavior.Strict);
-            locator.Setup(l => l.Alert()).Returns(alerter.Object);
+		/// <summary>
+		/// Tests the dismiss alert calls accept when close is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenCloseIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.Close, false);
+		}
+
+		/// <summary>
+		/// Tests the dismiss alert calls accept when ignore is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenIgnoreIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.Ignore, false);
+		}
+
+		/// <summary>
+		/// Tests the dismiss alert calls accept when no is chosen.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertAcceptsWhenNoIsChoosen()
+		{
+			TestAlertScenario(AlertBoxAction.No, false);
+		}
+
+		/// <summary>
+		/// Tests the dismiss alert calls accept when ok is chosen after entering text.
+		/// </summary>
+		[TestMethod]
+		public void TestDismissAlertEntersTextAndAcceptsWhenOkIsChoosen()
+		{
+			var alerter = new Mock<IAlert>(MockBehavior.Strict);
+			alerter.Setup(a => a.SendKeys("My Text"));
+			alerter.Setup(a => a.Accept());
+
+			var locator = new Mock<ITargetLocator>(MockBehavior.Strict);
+			locator.Setup(l => l.Alert()).Returns(alerter.Object);
 
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.SwitchTo()).Returns(locator.Object);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.DismissAlert(AlertBoxAction.Ok, "My Text");
-			}
+			});
 
 			alerter.VerifyAll();
-            driver.VerifyAll();
-            locator.VerifyAll();
-        }
+			locator.VerifyAll();
+		}
 
-        /// <summary>
-        /// Tests the close method does nothing when the driver has not been called.
-        /// </summary>
-        [TestMethod]
-        public void TestClosesDoesNothingWhenDriverIsNotInitialized()
-        {
-            var driver = new Mock<IWebDriver>(MockBehavior.Strict);
+		/// <summary>
+		/// Tests the close method does nothing when the driver has not been called.
+		/// </summary>
+		[TestMethod]
+		public void TestClosesDoesNothingWhenDriverIsNotInitialized()
+		{
+			var driver = new Mock<IWebDriver>(MockBehavior.Strict);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.Close();
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the close method is called if the driver has been used.
-        /// </summary>
-        [TestMethod]
-        public void TestClosesBrowserWhenDriverIsInitialized()
-        {
+		/// <summary>
+		/// Tests the close method is called if the driver has been used.
+		/// </summary>
+		[TestMethod]
+		public void TestClosesBrowserWhenDriverIsInitialized()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.Close());
 
-            var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
-
-            Assert.IsNotNull(lazyDriver.Value);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			this.InitializeDriverAndTestBrowserWith(driver, browser =>
 			{
 				browser.Close();
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the getting the page location returns the url value.
-        /// </summary>
-        [TestMethod]
-        public void TestGetNativePageLocationReturnsUrl()
-        {
+		/// <summary>
+		/// Tests the getting the page location returns the url value.
+		/// </summary>
+		[TestMethod]
+		public void TestGetNativePageLocationReturnsUrl()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.SetupGet(d => d.Url).Returns("http://localhost:2222/MyPage");
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.EnsureOnPage<MyPage>();
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the dispose method does nothing when the driver has not been called.
-        /// </summary>
-        [TestMethod]
-        public void TestDisposeDoesNothingWhenDriverIsNotInitialized()
-        {
+		/// <summary>
+		/// Tests the dispose method does nothing when the driver has not been called.
+		/// </summary>
+		[TestMethod]
+		public void TestDisposeDoesNothingWhenDriverIsNotInitialized()
+		{
 			var driver = this.CreateMockWebDriverNotExpectingInitialization();
 
-			var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the dispose method is called if the driver has been used.
-        /// </summary>
-        [TestMethod]
-        public void TestDisposeClosesBrowserWhenDriverIsInitialized()
-        {
+		/// <summary>
+		/// Tests the dispose method is called if the driver has been used.
+		/// </summary>
+		[TestMethod]
+		public void TestDisposeClosesBrowserWhenDriverIsInitialized()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
-			var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
 
-            Assert.IsNotNull(lazyDriver.Value);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			this.InitializeDriverAndTestBrowserWith(driver, browser =>
 			{
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the dispose is only called once.
-        /// </summary>
-        [TestMethod]
-        public void TestDisposeWhenCalledTwiceOnlyDisposesOnce()
-        {
+		/// <summary>
+		/// Tests the dispose is only called once.
+		/// </summary>
+		[TestMethod]
+		public void TestDisposeWhenCalledTwiceOnlyDisposesOnce()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
-			var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
 
-            Assert.IsNotNull(lazyDriver.Value);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			this.InitializeDriverAndTestBrowserWith(driver, browser =>
 			{
 				browser.Dispose();
-			}
+			});
 
-            driver.Verify(d => d.Quit(), Times.Exactly(1));
-            driver.Verify(d => d.Dispose(), Times.Exactly(1));
-            driver.VerifyAll();
-        }
+			driver.Verify(d => d.Quit(), Times.Exactly(1));
+			driver.Verify(d => d.Dispose(), Times.Exactly(1));
+		}
 
-        /// <summary>
-        /// Tests the execute script method for the browser when it exists.
-        /// </summary>
-        [TestMethod]
-        public void TestExecuteScriptWhenDriverSupportItRunsScript()
-        {
-            var result = new object();
+		/// <summary>
+		/// Tests the execute script method for the browser when it exists.
+		/// </summary>
+		[TestMethod]
+		public void TestExecuteScriptWhenDriverSupportItRunsScript()
+		{
+			var result = new object();
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.As<IJavaScriptExecutor>().Setup(e => e.ExecuteScript("some script", It.IsAny<object[]>()))
-                                            .Returns(result);
+											.Returns(result);
 
-            var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
-
-            Assert.IsNotNull(lazyDriver.Value);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			this.InitializeDriverAndTestBrowserWith(driver, browser =>
 			{
 				var resultObject = browser.ExecuteScript("some script", "Hello");
 				Assert.AreSame(result, resultObject);
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the execute script method for the browser when it exists.
-        /// </summary>
-        [TestMethod]
-        public void TestExecuteScriptWhenResultIsNativeElementReturnsProxyClass()
-        {
-            var result = new Mock<IWebElement>(MockBehavior.Strict);
+		/// <summary>
+		/// Tests the execute script method for the browser when it exists.
+		/// </summary>
+		[TestMethod]
+		public void TestExecuteScriptWhenResultIsNativeElementReturnsProxyClass()
+		{
+			var result = new Mock<IWebElement>(MockBehavior.Strict);
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.As<IJavaScriptExecutor>().Setup(e => e.ExecuteScript("some script", It.IsAny<object[]>()))
-                                            .Returns(result.Object);
+											.Returns(result.Object);
 
-            var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
-
-            Assert.IsNotNull(lazyDriver.Value);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			this.InitializeDriverAndTestBrowserWith(driver, browser =>
 			{
 				var resultObject = browser.ExecuteScript("some script", "Hello");
 
 				Assert.IsNotNull(resultObject);
 				Assert.IsInstanceOfType(resultObject, typeof(WebElement));
-			}
+			});
 
-            driver.VerifyAll();
-            result.VerifyAll();
-        }
+			result.VerifyAll();
+		}
 
-        /// <summary>
-        /// Tests the execute script method when it doesn't support it returns null.
-        /// </summary>
-        [TestMethod]
-        public void TestExecuteScriptWhenDriverDoesNotSupportScriptReturnsNull()
-        {
+		/// <summary>
+		/// Tests the execute script method when it doesn't support it returns null.
+		/// </summary>
+		[TestMethod]
+		public void TestExecuteScriptWhenDriverDoesNotSupportScriptReturnsNull()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
-			var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
 
-            Assert.IsNotNull(lazyDriver.Value);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			this.InitializeDriverAndTestBrowserWith(driver, browser =>
 			{
 				var resultObject = browser.ExecuteScript("some script", "Hello");
 
 				Assert.IsNull(resultObject);
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the take screenshot method does nothing when the interface is not supported.
-        /// </summary>
-        [TestMethod]
-        public void TestTakeScreenshotWhenNotSupportedDoesNothing()
-        {
+		/// <summary>
+		/// Tests the take screenshot method does nothing when the interface is not supported.
+		/// </summary>
+		[TestMethod]
+		public void TestTakeScreenshotWhenNotSupportedDoesNothing()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 
-			var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				var fullPath = browser.TakeScreenshot(@"C:\somepath", "fileBase");
 
 				Assert.IsNull(fullPath);
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the take screenshot method does nothing when the interface is not supported.
-        /// </summary>
-        [TestMethod]
-        public void TestTakeScreenshotWhenScreenshotErrorsReturnsNothing()
-        {
+		/// <summary>
+		/// Tests the take screenshot method does nothing when the interface is not supported.
+		/// </summary>
+		[TestMethod]
+		public void TestTakeScreenshotWhenScreenshotErrorsReturnsNothing()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.As<ITakesScreenshot>().Setup(s => s.GetScreenshot()).Throws<InvalidOperationException>();
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				var fullPath = browser.TakeScreenshot(@"C:\somepath", "fileBase");
 
 				Assert.IsNull(fullPath);
-			}
+			});
+		}
 
-            driver.VerifyAll();
-        }
-
-        /// <summary>
-        /// Tests the take screenshot method performs the appropriate calls.
-        /// </summary>
-        [TestMethod]
-        public void TestTakeScreenshotWhenCalledWithoutErrorTakesScreenshot()
-        {
+		/// <summary>
+		/// Tests the take screenshot method performs the appropriate calls.
+		/// </summary>
+		[TestMethod]
+		public void TestTakeScreenshotWhenCalledWithoutErrorTakesScreenshot()
+		{
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.As<ITakesScreenshot>().Setup(s => s.GetScreenshot()).Throws<InvalidOperationException>();
 
-            var basePath = Path.GetTempPath();
-            var fileName = Guid.NewGuid().ToString();
+			var basePath = Path.GetTempPath();
+			var fileName = Guid.NewGuid().ToString();
 
-            Screenshot screenshot;
-            using (var ms = new MemoryStream())
-            {
-                var image = TestResource.TestImage;
-                image.Save(ms, ImageFormat.Jpeg);
-
-                screenshot = new Screenshot(Convert.ToBase64String(ms.ToArray()));
-            }
-
-            var screenShot = driver.As<ITakesScreenshot>();
-            screenShot.Setup(s => s.GetScreenshot()).Returns(screenshot);
-
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			Screenshot screenshot;
+			using (var ms = new MemoryStream())
 			{
+				var image = TestResource.TestImage;
+				image.Save(ms, ImageFormat.Jpeg);
 
+				screenshot = new Screenshot(Convert.ToBase64String(ms.ToArray()));
+			}
+
+			var screenShot = driver.As<ITakesScreenshot>();
+			screenShot.Setup(s => s.GetScreenshot()).Returns(screenshot);
+
+			this.TestBrowserWith(driver, browser =>
+			{
 				string fullPath = null;
 
 				try
@@ -561,10 +494,36 @@ namespace SpecBind.Selenium.Tests
 				}
 
 				Assert.IsNotNull(fullPath);
+			});
+		}
+
+		private void InitializeDriverAndTestBrowserWith(Mock<IWebDriver> driver, Action<SeleniumBrowser> test)
+		{
+			this.TestBrowserWith(driver, true, test);
+		}
+
+		private void TestBrowserWith(Mock<IWebDriver> driver, Action<SeleniumBrowser> test)
+		{
+			this.TestBrowserWith(driver, false, test);
+		}
+
+		private void TestBrowserWith(Mock<IWebDriver> driver, bool initializeDriver, Action<SeleniumBrowser> test)
+		{
+			var lazyDriver = new Lazy<IWebDriver>(() => driver.Object);
+			if (initializeDriver)
+			{
+				Assert.IsNotNull(lazyDriver.Value);
+			}
+
+			var logger = new Mock<ILogger>(MockBehavior.Loose);
+
+			using (var browser = new SeleniumBrowser(lazyDriver, logger.Object))
+			{
+				test(browser);
 			}
 
 			driver.VerifyAll();
-        }
+		}
 
 		private Mock<IWebDriver> CreateMockWebDriverExpectingInitialization()
 		{
@@ -608,15 +567,12 @@ namespace SpecBind.Selenium.Tests
 			var driver = this.CreateMockWebDriverExpectingInitialization();
 			driver.Setup(d => d.SwitchTo()).Returns(locator.Object);
 
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
-
-			using (var browser = new SeleniumBrowser(new Lazy<IWebDriver>(() => driver.Object), logger.Object))
+			this.TestBrowserWith(driver, browser =>
 			{
 				browser.DismissAlert(action, null);
-			}
+			});
 
             alerter.VerifyAll();
-            driver.VerifyAll();
             locator.VerifyAll();
         }
 

--- a/src/SpecBind.Selenium/SeleniumBrowser.cs
+++ b/src/SpecBind.Selenium/SeleniumBrowser.cs
@@ -42,13 +42,6 @@ namespace SpecBind.Selenium
             this.pageCache = new Dictionary<Type, Func<IWebDriver, IBrowser, Action<object>, object>>();
         }
 
-		/*
-		 * Destructors don't play nice with strict mocks.
-		 * If the destructor operations aren't setup, then strict mocks cause the test runer to crash when the destructor is called.
-		 * If the destructor operations are setup, then VerifyAll() fails because they haven't been executed yet.
-		 *
-		 * Why not just ensure Dispose() gets called at the right time?
-		 */
         /// <summary>
         /// Finalizes an instance of the <see cref="SeleniumBrowser" /> class.
         /// </summary>

--- a/src/SpecBind.Selenium/SeleniumBrowserFactory.cs
+++ b/src/SpecBind.Selenium/SeleniumBrowserFactory.cs
@@ -102,13 +102,16 @@ namespace SpecBind.Selenium
             var managementSettings = driver.Manage();
            
             // Set timeouts
+
+			var applicationConfiguration = SpecBind.Helpers.SettingHelper.GetConfigurationSection().Application;
+
             managementSettings.Timeouts()
                 .ImplicitlyWait(browserFactoryConfiguration.ElementLocateTimeout)
                 .SetPageLoadTimeout(browserFactoryConfiguration.PageLoadTimeout);
 
-            WaitForElementAction.DefaultTimeout = browserFactoryConfiguration.ElementLocateTimeout;
-            WaitForListItemsAction.DefaultTimeout = browserFactoryConfiguration.ElementLocateTimeout;
+			ActionBase.DefaultTimeout = browserFactoryConfiguration.ElementLocateTimeout;
             WaitForPageAction.DefaultTimeout = browserFactoryConfiguration.PageLoadTimeout;
+			ActionBase.RetryValidationUntilTimeout = applicationConfiguration.RetryValidationUntilTimeout;
 
             // Maximize window
             managementSettings.Window.Maximize();
@@ -296,7 +299,6 @@ namespace SpecBind.Selenium
 
             if (browserFactoryConfiguration.EnsureCleanSession)
             {
-                Debug.WriteLine("SpecBind.Selenium.SeleniumBrowserFactory.GetFireFoxDriver: Clearing firefox cookies");
                 driver.Manage().Cookies.DeleteAllCookies();
             }
 

--- a/src/SpecBind.Tests/ActionPipeline/ActionPipelineServiceFixture.cs
+++ b/src/SpecBind.Tests/ActionPipeline/ActionPipelineServiceFixture.cs
@@ -139,41 +139,6 @@ namespace SpecBind.Tests.ActionPipeline
         }
 
         /// <summary>
-        /// Tests the pipeline call creates the action, invokes all pipeline steps and does not fail.
-        /// </summary>
-        [TestMethod]
-        public void TestPipelineCallCreatesActionAndRetriesOnFirstFailureThenDoesNotFail()
-        {
-            var context = new ActionContext("MyProperty");
-
-            var page = new Mock<IPage>(MockBehavior.Strict);
-
-            var preAction = new Mock<IPreAction>(MockBehavior.Strict);
-            preAction.Setup(p => p.PerformPreAction(It.IsAny<MockRetryAction>(), context));
-
-            var postAction = new Mock<IPostAction>(MockBehavior.Strict);
-            postAction.Setup(p => p.PerformPostAction(It.IsAny<MockRetryAction>(), context, It.IsAny<ActionResult>()));
-
-            var repository = new Mock<IActionRepository>(MockBehavior.Strict);
-            repository.Setup(r => r.GetPreActions()).Returns(new[] { preAction.Object });
-            repository.Setup(r => r.GetPostActions()).Returns(new[] { postAction.Object });
-            repository.Setup(r => r.GetLocatorActions()).Returns(new List<ILocatorAction>());
-            repository.Setup(r => r.CreateAction<MockRetryAction>()).Returns(new MockRetryAction());
-
-            var service = new ActionPipelineService(repository.Object) { ActionRetryLimit = 2 };
-
-            var result = service.PerformAction<MockRetryAction>(page.Object, context);
-
-            Assert.IsNotNull(result);
-            Assert.AreEqual(true, result.Success);
-
-            repository.VerifyAll();
-            page.VerifyAll();
-            preAction.VerifyAll();
-            postAction.VerifyAll();
-        }
-
-        /// <summary>
         /// A mock action class.
         /// </summary>
 	    public class MockAction : ActionBase

--- a/src/SpecBind.Tests/Actions/ValidateItemActionFixture.cs
+++ b/src/SpecBind.Tests/Actions/ValidateItemActionFixture.cs
@@ -4,22 +4,22 @@
 
 namespace SpecBind.Tests.Actions
 {
-    using System.Linq;
+	using System.Linq;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    using Moq;
+	using Moq;
 
-    using SpecBind.ActionPipeline;
-    using SpecBind.Actions;
-    using SpecBind.Pages;
-    using SpecBind.Tests.Validation;
-    using SpecBind.Validation;
+	using SpecBind.ActionPipeline;
+	using SpecBind.Actions;
+	using SpecBind.Pages;
+	using SpecBind.Tests.Validation;
+	using SpecBind.Validation;
 
-    /// <summary>
-    /// A test fixture for a validate item action
-    /// </summary>
-    [TestClass]
+	/// <summary>
+	/// A test fixture for a validate item action
+	/// </summary>
+	[TestClass]
     public class ValidateItemActionFixture
     {
         /// <summary>
@@ -159,5 +159,99 @@ namespace SpecBind.Tests.Actions
 
             locator.VerifyAll();
         }
-    }
+
+
+		/// <summary>
+		/// Tests the RetryValidationUntilTimeout configuration attribute,
+		/// with initial failure but subsequent success returned before the timeout.
+		/// </summary>
+		[TestMethod]
+		public void TestRetryValidationUntilTimeoutWithEventualSuccessBeforeTimeout()
+		{
+			try
+			{
+				ValidateItemAction.RetryValidationUntilTimeout = true;
+				ActionBase.DefaultTimeout = System.TimeSpan.FromSeconds(5); // NOTE: interval between checks is 200ms
+
+				var table = new ValidationTable();
+				table.AddValidation("name", "My Data", "equals");
+				table.Process();
+
+				var propData = new Mock<IPropertyData>(MockBehavior.Strict);
+				string actualValue;
+				propData.SetupSequence(p => p.ValidateItem(table.Validations.First(), out actualValue))
+					.Returns(false)
+					.Returns(true); // after 200ms -- just in time
+
+				var propertyData = propData.Object;
+				var locator = new Mock<IElementLocator>(MockBehavior.Strict);
+				locator.Setup(p => p.TryGetProperty("name", out propertyData)).Returns(true);
+
+				var validateItemAction = new ValidateItemAction
+				{
+					ElementLocator = locator.Object
+				};
+
+				var context = new ValidateItemAction.ValidateItemContext(table);
+
+				var result = validateItemAction.Execute(context);
+
+				Assert.IsTrue(result.Success);
+
+				locator.VerifyAll();
+			}
+			finally
+			{
+				ValidateItemAction.RetryValidationUntilTimeout = false;
+				ActionBase.DefaultTimeout = System.TimeSpan.FromSeconds(5);
+			}
+		}
+
+		/// <summary>
+		/// Tests the RetryValidationUntilTimeout configuration attribute,
+		/// with initial failure but subsequent success returned before the timeout.
+		/// </summary>
+		[TestMethod]
+		public void TestRetryValidationUntilTimeoutWithNoSuccessBeforeTimeout()
+		{
+			try
+			{
+				ValidateItemAction.RetryValidationUntilTimeout = true;
+				ActionBase.DefaultTimeout = System.TimeSpan.FromMilliseconds(300); // NOTE: interval between checks is 200ms
+
+				var table = new ValidationTable();
+				table.AddValidation("name", "My Data", "equals");
+				table.Process();
+
+				var propData = new Mock<IPropertyData>(MockBehavior.Strict);
+				string actualValue;
+				propData.SetupSequence(p => p.ValidateItem(table.Validations.First(), out actualValue))
+					.Returns(false)
+					.Returns(false) // after 200ms
+					.Returns(true); // after 400ms -- too late
+
+				var propertyData = propData.Object;
+				var locator = new Mock<IElementLocator>(MockBehavior.Strict);
+				locator.Setup(p => p.TryGetProperty("name", out propertyData)).Returns(true);
+
+				var validateItemAction = new ValidateItemAction
+				{
+					ElementLocator = locator.Object
+				};
+
+				var context = new ValidateItemAction.ValidateItemContext(table);
+
+				var result = validateItemAction.Execute(context);
+
+				Assert.IsFalse(result.Success);
+
+				locator.VerifyAll();
+			}
+			finally
+			{
+				ValidateItemAction.RetryValidationUntilTimeout = false;
+				ActionBase.DefaultTimeout = System.TimeSpan.FromSeconds(5);
+			}
+		}
+	}
 }

--- a/src/SpecBind.Tests/App.config
+++ b/src/SpecBind.Tests/App.config
@@ -4,7 +4,7 @@
     <section name="specBind" type="SpecBind.Configuration.ConfigurationSectionHandler, SpecBind"/>
   </configSections>
   <specBind>
-    <application startUrl="http://localhost:2222" actionRetryLimit="1" waitForStillElementBeforeClicking="true" />
-    <browserFactory provider="SpecBind.Tests.Support.MockBrowserFactory, SpecBind.Tests" browserType="IE"/>
+    <application startUrl="http://localhost:2222" retryValidationUntilTimeout="false" waitForStillElementBeforeClicking="true" />
+    <browserFactory provider="SpecBind.Tests.Support.MockBrowserFactory, SpecBind.Tests" browserType="IE" />
   </specBind>
 </configuration>

--- a/src/SpecBind.Tests/BrowserBaseFixture.cs
+++ b/src/SpecBind.Tests/BrowserBaseFixture.cs
@@ -3,23 +3,23 @@
 // </copyright>
 namespace SpecBind.Tests
 {
-    using System;
-    using System.Collections.Generic;
+	using System;
+	using System.Collections.Generic;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    using Moq;
-    using Moq.Protected;
+	using Moq;
+	using Moq.Protected;
 
-    using SpecBind.Actions;
-    using SpecBind.BrowserSupport;
-    using SpecBind.Helpers;
-    using SpecBind.Pages;
+	using SpecBind.Actions;
+	using SpecBind.BrowserSupport;
+	using SpecBind.Helpers;
+	using SpecBind.Pages;
 
-    /// <summary>
-    /// A test fixture for the <see cref="BrowserBase"/> class.
-    /// </summary>
-    [TestClass]
+	/// <summary>
+	/// A test fixture for the <see cref="BrowserBase"/> class.
+	/// </summary>
+	[TestClass]
     public class BrowserBaseFixture
     {
         /// <summary>
@@ -186,18 +186,20 @@ namespace SpecBind.Tests
         [TestMethod]
         public void TestCloseWhenDisposeIsTrue()
         {
+			bool disposingManagedResources = true;
+
             var logger = new Mock<ILogger>(MockBehavior.Loose);
             var browser = new Mock<BrowserBase>(MockBehavior.Strict, logger.Object);
             browser.Setup(b => b.Close());
-            browser.Protected().Setup("DisposeWindow");
+            browser.Protected().Setup("DisposeWindow", disposingManagedResources);
 
             var browserInstance = browser.Object;
-            browserInstance.Close(true);
+            browserInstance.Close(dispose: true);
 
             Assert.IsTrue(browserInstance.IsDisposed);
 
             browser.Verify(b => b.Close());
-            browser.Protected().Verify("DisposeWindow", Times.Once());
+            browser.Protected().Verify("DisposeWindow", Times.Once(), disposingManagedResources);
         }
 
         /// <summary>
@@ -206,18 +208,20 @@ namespace SpecBind.Tests
         [TestMethod]
         public void TestCloseWhenDisposeIsFalse()
         {
-            var logger = new Mock<ILogger>(MockBehavior.Loose);
+			bool disposingManagedResources = true;
+
+			var logger = new Mock<ILogger>(MockBehavior.Loose);
             var browser = new Mock<BrowserBase>(MockBehavior.Strict, logger.Object);
             browser.Setup(b => b.Close());
-            browser.Protected().Setup("DisposeWindow");
+            browser.Protected().Setup("DisposeWindow", disposingManagedResources);
 
             var browserInstance = browser.Object;
-            browserInstance.Close(false);
+            browserInstance.Close(dispose: false);
 
             Assert.IsFalse(browserInstance.IsDisposed);
 
             browser.Verify(b => b.Close());
-            browser.Protected().Verify("DisposeWindow", Times.Never());
+            browser.Protected().Verify("DisposeWindow", Times.Never(), disposingManagedResources);
         }
 
 

--- a/src/SpecBind.Tests/WaitingStepsFixture.cs
+++ b/src/SpecBind.Tests/WaitingStepsFixture.cs
@@ -13,6 +13,8 @@ namespace SpecBind.Tests
     using SpecBind.Actions;
     using SpecBind.Helpers;
     using SpecBind.Pages;
+	using SpecBind.BrowserSupport;
+	using BoDi;
 
     /// <summary>
     /// A test fixture for the <see cref="WaitingSteps"/> step class.
@@ -579,5 +581,97 @@ namespace SpecBind.Tests
             testPage.VerifyAll();
             scenarioContext.VerifyAll();
         }
+
+		/// <summary>
+		/// Tests the IWaitForAngularAjaxCallsToComplete with a successful result, when nothing is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestIWaitForAngularAjaxCallsToCompleteStepWithNothingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.Setup(s => s.ExecuteScript(It.IsAny<string>())).Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			var pipelineService = new Mock<IActionPipelineService>(MockBehavior.Strict);
+			var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
+			var steps = new WaitingSteps(pipelineService.Object, scenarioContext.Object);
+
+			steps.WaitForAngular();
+
+			browser.VerifyAll();
+		}
+
+		/// <summary>
+		/// Tests the IWaitForAngularAjaxCallsToComplete with a successful result, when something is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestIWaitForAngularAjaxCallsToCompleteStepWithSomethingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.SetupSequence(s => s.ExecuteScript(It.IsAny<string>()))
+				.Returns("1")
+				.Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			var pipelineService = new Mock<IActionPipelineService>(MockBehavior.Strict);
+			var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
+			var steps = new WaitingSteps(pipelineService.Object, scenarioContext.Object);
+
+			steps.WaitForAngular();
+
+			browser.VerifyAll();
+		}
+
+		/// <summary>
+		/// Tests the IWaitForjQueryAjaxCallsToComplete with a successful result, when nothing is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestIWaitForjQueryAjaxCallsToCompleteStepWithNothingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.Setup(s => s.ExecuteScript(It.IsAny<string>())).Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			var pipelineService = new Mock<IActionPipelineService>(MockBehavior.Strict);
+			var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
+			var steps = new WaitingSteps(pipelineService.Object, scenarioContext.Object);
+
+			steps.WaitForjQuery();
+
+			browser.VerifyAll();
+		}
+
+		/// <summary>
+		/// Tests the IWaitForjQueryAjaxCallsToComplete with a successful result, when something is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestIWaitForjQueryAjaxCallsToCompleteStepWithSomethingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.SetupSequence(s => s.ExecuteScript(It.IsAny<string>()))
+				.Returns("1")
+				.Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			var pipelineService = new Mock<IActionPipelineService>(MockBehavior.Strict);
+			var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
+			var steps = new WaitingSteps(pipelineService.Object, scenarioContext.Object);
+
+			steps.WaitForjQuery();
+
+			browser.VerifyAll();
+		}
     }
 }

--- a/src/SpecBind.Tests/WebDriverSupportFixture.cs
+++ b/src/SpecBind.Tests/WebDriverSupportFixture.cs
@@ -4,28 +4,28 @@
 
 namespace SpecBind.Tests
 {
-    using System;
+	using System;
 
-    using BoDi;
+	using BoDi;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    using Moq;
+	using Moq;
 
-    using SpecBind.ActionPipeline;
-    using SpecBind.Actions;
-    using SpecBind.BrowserSupport;
-    using SpecBind.Configuration;
-    using SpecBind.Helpers;
-    using SpecBind.Pages;
-    using SpecBind.Validation;
+	using SpecBind.ActionPipeline;
+	using SpecBind.Actions;
+	using SpecBind.BrowserSupport;
+	using SpecBind.Configuration;
+	using SpecBind.Helpers;
+	using SpecBind.Pages;
+	using SpecBind.Validation;
 
-    using TechTalk.SpecFlow.Tracing;
+	using TechTalk.SpecFlow.Tracing;
 
-    /// <summary>
-    /// A test fixture for the Web Driver class.
-    /// </summary>
-    [TestClass]
+	/// <summary>
+	/// A test fixture for the Web Driver class.
+	/// </summary>
+	[TestClass]
     public class WebDriverSupportFixture
     {
         /// <summary>
@@ -34,11 +34,11 @@ namespace SpecBind.Tests
         [TestMethod]
         public void TestInitializeTests()
         {
-            var logger = new Mock<ILogger>();
+			var logger = new Mock<ILogger>();
 
             var container = new Mock<IObjectContainer>(MockBehavior.Strict);
-            container.Setup(c => c.RegisterInstanceAs(It.IsAny<IBrowser>(), null, true));
-            container.Setup(c => c.RegisterInstanceAs<ISettingHelper>(It.IsAny<WrappedSettingHelper>(), null, false));
+			container.Setup(c => c.RegisterInstanceAs(It.IsAny<IBrowser>(), null, false));
+			container.Setup(c => c.RegisterInstanceAs<ISettingHelper>(It.IsAny<WrappedSettingHelper>(), null, false));
             container.Setup(c => c.RegisterInstanceAs(It.IsAny<IPageMapper>(), null, false));
             container.Setup(c => c.RegisterTypeAs<ScenarioContextHelper, IScenarioContextHelper>(null));
             container.Setup(c => c.RegisterTypeAs<TokenManager, ITokenManager>(null));
@@ -50,10 +50,10 @@ namespace SpecBind.Tests
             container.Setup(c => c.Resolve(It.Is<Type>(t => typeof(ILocatorAction).IsAssignableFrom(t)), null)).Returns(new Mock<ILocatorAction>().Object);
             container.Setup(c => c.Resolve(It.Is<Type>(t => typeof(IPreAction).IsAssignableFrom(t)), null)).Returns(new Mock<IPreAction>().Object);
             container.Setup(c => c.Resolve(It.Is<Type>(t => typeof(IValidationComparer).IsAssignableFrom(t)), null)).Returns(new Mock<IValidationComparer>().Object);
-
+            
             var driverSupport = new WebDriverSupport(container.Object);
 
-            driverSupport.InitializeDriver();
+			driverSupport.InitializeDriver();
 
             container.VerifyAll();
         }
@@ -118,7 +118,7 @@ namespace SpecBind.Tests
         public void TestCheckForScreenshotWithErrorAttemptsScreenshotButFails()
         {
             var listener = new Mock<ITraceListener>(MockBehavior.Strict);
-
+            
             var scenarioContext = new Mock<IScenarioContextHelper>(MockBehavior.Strict);
             scenarioContext.Setup(s => s.GetError()).Returns(new InvalidOperationException());
             scenarioContext.Setup(s => s.GetStepFileName()).Returns("TestFileName");
@@ -193,7 +193,7 @@ namespace SpecBind.Tests
         [TestMethod]
         public void TestTearDownAfterScenarioWhenReuseBrowserIsTrue()
         {
-
+            
             // arrange
             var config = new ConfigurationSectionHandler
             {
@@ -242,5 +242,81 @@ namespace SpecBind.Tests
             // assert
             browser.VerifyAll();
         }
+
+		/// <summary>
+		/// Tests WaitForAngular with a successful result, when nothing is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestWaitForAngularWithNothingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.Setup(s => s.ExecuteScript(It.IsAny<string>())).Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			WebDriverSupport.WaitForAngular();
+
+			browser.VerifyAll();
+		}
+
+		/// <summary>
+		/// Tests WaitForAngular with a successful result, when something is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestWaitForAngularWithSomethingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.SetupSequence(s => s.ExecuteScript(It.IsAny<string>()))
+				.Returns("1")
+				.Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			WebDriverSupport.WaitForAngular();
+
+			browser.VerifyAll();
+		}
+
+		/// <summary>
+		/// Tests WaitForjQuery with a successful result, when nothing is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestWaitForjQueryWithNothingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.Setup(s => s.ExecuteScript(It.IsAny<string>())).Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			WebDriverSupport.WaitForjQuery();
+
+			browser.VerifyAll();
+		}
+
+		/// <summary>
+		/// Tests WaitForjQuery with a successful result, when something is pending.
+		/// </summary>
+		[TestMethod]
+		public void TestWaitForjQueryWithSomethingPending()
+		{
+			var browser = new Mock<IBrowser>(MockBehavior.Strict);
+			browser.Setup(s => s.IsClosed).Returns(false);
+			browser.Setup(s => s.IsDisposed).Returns(false);
+			browser.Setup(s => s.Url).Returns("http://www.specbind.org");
+			browser.SetupSequence(s => s.ExecuteScript(It.IsAny<string>()))
+				.Returns("1")
+				.Returns("0");
+			WebDriverSupport.Browser = browser.Object;
+
+			WebDriverSupport.WaitForjQuery();
+
+			browser.VerifyAll();
+		}
     }
 }

--- a/src/SpecBind/ActionPipeline/ActionPipelineService.cs
+++ b/src/SpecBind/ActionPipeline/ActionPipelineService.cs
@@ -7,7 +7,7 @@ namespace SpecBind.ActionPipeline
 	using System;
 
 	using SpecBind.Helpers;
-    using SpecBind.Pages;
+	using SpecBind.Pages;
 
 	/// <summary>
 	/// A class that manages actions that should be taken during parts of the process
@@ -24,13 +24,12 @@ namespace SpecBind.ActionPipeline
 	{
 		private readonly IActionRepository actionRepository;
 
-        /// <summary>
+		/// <summary>
         /// Initializes the <see cref="ActionPipelineService"/> class.
         /// </summary>
         static ActionPipelineService()
 		{
 			var configSection = SettingHelper.GetConfigurationSection();
-			ConfiguredActionRetryLimit = configSection.Application.ActionRetryLimit;
 		}
 
         /// <summary>
@@ -38,25 +37,11 @@ namespace SpecBind.ActionPipeline
 		/// </summary>
 		/// <param name="actionRepository">The action repository.</param>
 		public ActionPipelineService(IActionRepository actionRepository)
-        {
-            this.actionRepository = actionRepository;
-            this.ActionRetryLimit = ConfiguredActionRetryLimit;
-        }
+		{
+			this.actionRepository = actionRepository;
+		}
 
         /// <summary>
-        /// Gets or sets the number of times to retry a failed action.
-        /// </summary>
-        public int ActionRetryLimit { get; set; }
-
-        /// <summary>
-        /// Gets or sets the configured action retry limit.
-        /// </summary>
-        /// <value>
-        /// The configured action retry limit.
-        /// </value>
-        protected internal static int ConfiguredActionRetryLimit { get; set; }
-
-		/// <summary>
         /// Performs the action.
         /// </summary>
         /// <typeparam name="TAction">The type of the action.</typeparam>
@@ -85,30 +70,14 @@ namespace SpecBind.ActionPipeline
 			this.PerformPreAction(action, context);
 
 			ActionResult result = null;
-
-			int tries = 0;
-			do
+			try
 			{
-				if (tries++ > 0)
-				{
-					System.Threading.Thread.Sleep(1000);
-				}
-
-			    try
-			    {
-				    result = action.Execute(context);
-                        if (result.Success)
-                        {
-                            break;
-                        }
-
-			    }
-			    catch (Exception ex)
-			    {
-				    result = ActionResult.Failure(ex);
-			    }
+				result = action.Execute(context);
 			}
-			while (tries <= this.ActionRetryLimit);
+			catch (Exception ex)
+			{
+				result = ActionResult.Failure(ex);
+			}
 
             this.PerformPostAction(action, context, result);
 

--- a/src/SpecBind/ActionPipeline/IActionPipelineService.cs
+++ b/src/SpecBind/ActionPipeline/IActionPipelineService.cs
@@ -4,18 +4,13 @@
 
 namespace SpecBind.ActionPipeline
 {
-    using SpecBind.Pages;
+	using SpecBind.Pages;
 
 	/// <summary>
 	/// Represents the action pipeline that performs actions.
 	/// </summary>
 	public interface IActionPipelineService
 	{
-		/// <summary>
-		/// Gets or sets the number of times to retry a failed action.
-		/// </summary>
-		int ActionRetryLimit { get; set; }
-
         /// <summary>
         /// Performs the action.
         /// </summary>

--- a/src/SpecBind/Actions/ActionBase.cs
+++ b/src/SpecBind/Actions/ActionBase.cs
@@ -4,7 +4,8 @@
 
 namespace SpecBind.Actions
 {
-    using SpecBind.ActionPipeline;
+	using System;
+	using SpecBind.ActionPipeline;
 
 	/// <summary>
 	/// A base class for an action in the pipeline.
@@ -14,6 +15,14 @@ namespace SpecBind.Actions
 		private readonly string actionName;
 
 		/// <summary>
+		/// Initializes the ActionBase type.
+		/// </summary>
+		static ActionBase()
+		{
+			DefaultTimeout = TimeSpan.FromSeconds(30);
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="ActionBase"/> class.
 		/// </summary>
 		/// <param name="actionName">Name of the action.</param>
@@ -21,6 +30,19 @@ namespace SpecBind.Actions
 		{
 			this.actionName = actionName;
 		}
+
+		/// <summary>
+		/// Gets or sets the default timeout to wait.
+		/// </summary>
+		/// <value>
+		/// The timeout.
+		/// </value>
+		public static TimeSpan DefaultTimeout { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether or not to keep retrying validations, until the timeout.
+		/// </summary>
+		public static bool RetryValidationUntilTimeout { get; set; }
 
 		/// <summary>
 		/// Gets the action name.

--- a/src/SpecBind/Actions/ValidateActionBase.cs
+++ b/src/SpecBind/Actions/ValidateActionBase.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="ValidateActionBase.cs">
+//    Copyright © 2013 Dan Piessens  All rights reserved.
+// </copyright>
+
+namespace SpecBind.Actions
+{
+	using System;
+	using SpecBind.ActionPipeline;
+	using SpecBind.Helpers;
+
+	/// <summary>
+	/// A convenience class for validation actions that may support retrying until a given timeout.
+	/// </summary>
+	/// <typeparam name="TContext">The type of the context.</typeparam>
+	public abstract class ValidateActionBase<TContext> : ContextActionBase<TContext>
+		where TContext : ActionContext
+	{
+		/// <summary>
+		/// Ctor
+		/// </summary>
+		/// <param name="concreteClassName">The name of the implementing class.</param>
+		public ValidateActionBase(string concreteClassName) : base(concreteClassName)
+		{
+		}
+
+		/// <summary>
+		/// Perform standard handling around user-supplied core validation logic.
+		/// </summary>
+		/// <typeparam name="T">The type of the argument.</typeparam>
+		/// <param name="arg">The argument to pass to the validator.</param>
+		/// <param name="validator">The underlying validation method.</param>
+		/// <remarks>If RetryValidationUntilTimeout is set, the validator will be called
+		/// until it returns <c>true</c> or the timeout expires.</remarks>
+		protected void DoValidate<T>(T arg, Func<T, bool> validator)
+		{
+			if (!RetryValidationUntilTimeout)
+			{
+				validator(arg);
+				return;
+			}
+
+			int attemptsCompleted = 0;
+			try
+			{
+				var waiter = new Waiter<T>();
+				waiter.WaitFor(arg, e =>
+					{
+						bool result = validator(e);
+						attemptsCompleted++;
+						if (!result)
+						{
+							LogDebug(() => "    (expected condition not yet met)");
+						}
+
+						return result;
+					});
+			}
+			catch (TimeoutException)
+			{
+				if (attemptsCompleted == 0)
+				{
+					throw;
+				}
+			}
+		}
+
+		private static void LogDebug(Func<string> messageGenerator)
+		{
+			if (!System.Diagnostics.Debugger.IsAttached)
+			{
+				return;
+			}
+
+			System.Diagnostics.Debug.WriteLine(messageGenerator());
+		}
+	}
+}

--- a/src/SpecBind/Actions/ValidateActionBase.cs
+++ b/src/SpecBind/Actions/ValidateActionBase.cs
@@ -42,7 +42,7 @@ namespace SpecBind.Actions
 			int attemptsCompleted = 0;
 			try
 			{
-				var waiter = new Waiter<T>();
+				var waiter = new Waiter<T>(DefaultTimeout);
 				waiter.WaitFor(arg, e =>
 					{
 						bool result = validator(e);

--- a/src/SpecBind/Actions/ValidateItemAction.cs
+++ b/src/SpecBind/Actions/ValidateItemAction.cs
@@ -3,14 +3,16 @@
 // </copyright>
 namespace SpecBind.Actions
 {
-    using SpecBind.ActionPipeline;
+	using System;
+	using SpecBind.ActionPipeline;
+	using SpecBind.Helpers;
     using SpecBind.Pages;
     using SpecBind.Validation;
 
     /// <summary>
     /// An action that helps perform item validation.
     /// </summary>
-    internal class ValidateItemAction : ContextActionBase<ValidateItemAction.ValidateItemContext>
+	public class ValidateItemAction : ValidateActionBase<ValidateItemAction.ValidateItemContext>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateItemAction"/> class.
@@ -20,7 +22,7 @@ namespace SpecBind.Actions
         {
         }
 
-        /// <summary>
+		/// <summary>
         /// Executes the specified action based on the context.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -51,10 +53,18 @@ namespace SpecBind.Actions
                 return false;
             }
 
-            string actualValue;
-            var successful = propertyData.ValidateItem(validation, out actualValue);
-            itemResult.NoteValidationResult(validation, successful, actualValue);
-            return successful;
+
+			string actualValue = null;
+			bool? successful = null;
+
+			this.DoValidate<IPropertyData>(propertyData, e =>
+				{
+					successful = e.ValidateItem(validation, out actualValue);
+					return successful.Value;
+				});
+
+			itemResult.NoteValidationResult(validation, successful.Value, actualValue);
+			return successful.Value;
         }
 
         /// <summary>

--- a/src/SpecBind/Actions/ValidateListAction.cs
+++ b/src/SpecBind/Actions/ValidateListAction.cs
@@ -8,13 +8,14 @@ namespace SpecBind.Actions
     using System.Linq;
 
     using SpecBind.ActionPipeline;
+	using SpecBind.Helpers;
     using SpecBind.Pages;
     using SpecBind.Validation;
 
     /// <summary>
     /// An action that validates a list of items for specific actions.
     /// </summary>
-    public class ValidateListAction : ContextActionBase<ValidateListAction.ValidateListContext>
+	public class ValidateListAction : ValidateActionBase<ValidateListAction.ValidateListContext>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateListAction"/> class.
@@ -41,7 +42,14 @@ namespace SpecBind.Actions
                             propertyData.Name));
             }
 
-            var validationResult = propertyData.ValidateList(actionContext.CompareType, actionContext.ValidationTable.Validations.ToList());
+			ValidationResult validationResult = null;
+
+			this.DoValidate<IPropertyData>(propertyData, e =>
+				{
+					validationResult = e.ValidateList(actionContext.CompareType, actionContext.ValidationTable.Validations.ToList());
+					return validationResult.IsValid;
+				});
+
             if (validationResult.IsValid)
             {
                 return ActionResult.Successful();

--- a/src/SpecBind/Actions/ValidateListRowCountAction.cs
+++ b/src/SpecBind/Actions/ValidateListRowCountAction.cs
@@ -4,12 +4,14 @@
 namespace SpecBind.Actions
 {
     using SpecBind.ActionPipeline;
+	using SpecBind.Helpers;
     using SpecBind.Pages;
+	using System;
 
     /// <summary>
     /// An action that validates a list of items for specific actions.
     /// </summary>
-    public class ValidateListRowCountAction : ContextActionBase<ValidateListRowCountAction.ValidateListRowCountContext>
+	public class ValidateListRowCountAction : ValidateActionBase<ValidateListRowCountAction.ValidateListRowCountContext>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidateListRowCountAction"/> class.
@@ -36,18 +38,25 @@ namespace SpecBind.Actions
                         propertyData.Name));
             }
 
-            var validationResult = propertyData.ValidateListRowCount(actionContext.CompareType, actionContext.RowCount);
-            if (validationResult.Item1)
-            {
-                return ActionResult.Successful();
-            }
+			Tuple<bool, int> validationResult = null;
 
-            return ActionResult.Failure(
-                new ElementExecuteException(
-                    "List count validation of field '{0}' failed. Expected Items: {1}, Actual Items: {2}",
-                    propertyData.Name,
-                    actionContext.RowCount,
-                    validationResult.Item2));
+			this.DoValidate<IPropertyData>(propertyData, e =>
+				{
+					validationResult = e.ValidateListRowCount(actionContext.CompareType, actionContext.RowCount);
+					return validationResult.Item1;
+				});
+
+			if (validationResult.Item1)
+			{
+				return ActionResult.Successful();
+			}
+
+			return ActionResult.Failure(
+					new ElementExecuteException(
+						"List count validation of field '{0}' failed. Expected Items: {1}, Actual Items: {2}",
+						propertyData.Name,
+						actionContext.RowCount,
+						validationResult.Item2));
         }
 
         /// <summary>

--- a/src/SpecBind/Actions/WaitForPageAction.cs
+++ b/src/SpecBind/Actions/WaitForPageAction.cs
@@ -4,18 +4,18 @@
 
 namespace SpecBind.Actions
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
+	using System;
+	using System.Threading;
+	using System.Threading.Tasks;
 
-    using SpecBind.ActionPipeline;
-    using SpecBind.BrowserSupport;
-    using SpecBind.Pages;
+	using SpecBind.ActionPipeline;
+	using SpecBind.BrowserSupport;
+	using SpecBind.Pages;
 
-    /// <summary>
-    /// An action that waits for the framework url to resolve to a certain page.
-    /// </summary>
-    public class WaitForPageAction : ContextActionBase<WaitForPageAction.WaitForPageActionContext>
+	/// <summary>
+	/// An action that waits for the framework url to resolve to a certain page.
+	/// </summary>
+	public class WaitForPageAction : ContextActionBase<WaitForPageAction.WaitForPageActionContext>
     {
         private readonly IBrowser browser;
         private readonly ILogger logger;
@@ -49,7 +49,7 @@ namespace SpecBind.Actions
         /// <value>
         /// The default timeout, 30 seconds.
         /// </value>
-        public static TimeSpan DefaultTimeout { get; set; }
+        public static new TimeSpan DefaultTimeout { get; set; }
 
         /// <summary>
         /// Executes this instance action.
@@ -66,7 +66,7 @@ namespace SpecBind.Actions
                     "Cannot locate a page for name: {0}. Check page aliases in the test assembly.", actionContext.PropertyName));
             }
 
-            var timeout = actionContext.Timeout.GetValueOrDefault(DefaultTimeout);
+            var timeout = actionContext.Timeout.GetValueOrDefault(WaitForPageAction.DefaultTimeout);
             var cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.CancelAfter(timeout);
             var token = cancellationTokenSource.Token;

--- a/src/SpecBind/BrowserSupport/BrowserBase.cs
+++ b/src/SpecBind/BrowserSupport/BrowserBase.cs
@@ -4,18 +4,18 @@
 
 namespace SpecBind.BrowserSupport
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
 
-    using SpecBind.Actions;
-    using SpecBind.Pages;
-    using UriHelper = Helpers.UriHelper;
+	using SpecBind.Actions;
+	using SpecBind.Pages;
+	using UriHelper = Helpers.UriHelper;
 
-    /// <summary>
-    /// A set of extension methods for the <see cref="IBrowser" /> interface.
-    /// </summary>
-    public abstract class BrowserBase : IBrowser
+	/// <summary>
+	/// A set of extension methods for the <see cref="IBrowser" /> interface.
+	/// </summary>
+	public abstract class BrowserBase : IBrowser
     {
         private readonly ILogger logger;
         private bool disposed;
@@ -43,49 +43,62 @@ namespace SpecBind.BrowserSupport
         /// </value>
         public abstract string Url { get; }
 
-        /// <summary>
-        /// Gets a value indicating whether this instance is disposed.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is disposed; otherwise, <c>false</c>.
-        /// </value>
-        internal bool IsDisposed
+		/// <summary>
+		/// Gets a value indicating whether or not the browser has been closed.
+		/// </summary>
+		public bool IsClosed { get; private set; }
+
+		/// <summary>
+		/// Gets a value indicating whether this instance is disposed.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if this instance is disposed; otherwise, <c>false</c>.
+		/// </value>
+		public bool IsDisposed
         {
             get { return this.disposed; }
         }
 
-        /// <summary>
-        /// Adds the cookie to the browser.
-        /// </summary>
-        /// <param name="name">The cookie name.</param>
-        /// <param name="value">The cookie value.</param>
-        /// <param name="path">The path.</param>
-        /// <param name="expireDateTime">The expiration date time.</param>
-        /// <param name="domain">The cookie domain.</param>
-        /// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
-        public abstract void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
+		/// <summary>
+		/// Adds the cookie to the browser.
+		/// </summary>
+		/// <param name="name">The cookie name.</param>
+		/// <param name="value">The cookie value.</param>
+		/// <param name="path">The path.</param>
+		/// <param name="expireDateTime">The expiration date time.</param>
+		/// <param name="domain">The cookie domain.</param>
+		/// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
+		public abstract void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
 
         /// <summary>
         /// Clear all browser cookies
         /// </summary>
         public abstract void ClearCookies();
 
+		/// <summary>
+		/// Clears the URL.
+		/// </summary>
+		public abstract void ClearUrl();
+
         /// <summary>
         /// Closes this instance.
         /// </summary>
         public abstract void Close();
 
-        /// <summary>
+		/// <summary>
         /// Closes the instance and optionally dispose of all resources
         /// </summary>
         /// <param name="dispose">Whether or not resources should get disposed</param>
         public void Close(bool dispose)
         {
             this.Close();
+
             if (dispose)
             {
                 this.Dispose();
             }
+
+			this.IsClosed = true;
         }
 
         /// <summary>
@@ -232,12 +245,12 @@ namespace SpecBind.BrowserSupport
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected void Dispose(bool disposing)
         {
-            if (!disposing || this.disposed)
+            if (this.disposed)
             {
                 return;
             }
 
-            this.DisposeWindow();
+            this.DisposeWindow(disposing);
 
             this.disposed = true;
         }
@@ -257,9 +270,10 @@ namespace SpecBind.BrowserSupport
         /// <returns>A page interface.</returns>
         protected abstract IPage CreateNativePage(Type pageType, bool verifyPageValidity);
 
-        /// <summary>
-        /// Releases windows and driver specific resources. This method is already protected by the base instance.
-        /// </summary>
-        protected abstract void DisposeWindow();
+		/// <summary>
+		/// Releases windows and driver specific resources. This method is already protected by the base instance.
+		/// </summary>
+		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+		protected abstract void DisposeWindow(bool disposing);
     }
 }

--- a/src/SpecBind/BrowserSupport/IBrowser.cs
+++ b/src/SpecBind/BrowserSupport/IBrowser.cs
@@ -4,15 +4,15 @@
 
 namespace SpecBind.BrowserSupport
 {
-    using System;
-    using System.Collections.Generic;
+	using System;
+	using System.Collections.Generic;
 
-    using SpecBind.Pages;
+	using SpecBind.Pages;
 
-    /// <summary>
-    /// An interface to describe browser methods.
-    /// </summary>
-    public interface IBrowser : IDisposable
+	/// <summary>
+	/// An interface to describe browser methods.
+	/// </summary>
+	public interface IBrowser : IDisposable
     {
         /// <summary>
         /// Gets the type of the base page.
@@ -28,23 +28,38 @@ namespace SpecBind.BrowserSupport
         /// <value>
         /// The url of the base page.
         /// </value>
-        string Url { get; }
+		string Url { get; }
 
-        /// <summary>
-        /// Adds the cookie to the browser.
-        /// </summary>
-        /// <param name="name">The cookie name.</param>
-        /// <param name="value">The cookie value.</param>
-        /// <param name="path">The path.</param>
-        /// <param name="expireDateTime">The expiration date time.</param>
-        /// <param name="domain">The cookie domain.</param>
-        /// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
-        void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
+		/// <summary>
+		/// Gets a value indicating whether or not the browser has been closed.
+		/// </summary>
+		bool IsClosed { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether or not the browser has been disposed.
+		/// </summary>
+		bool IsDisposed { get; }
+
+		/// <summary>
+		/// Adds the cookie to the browser.
+		/// </summary>
+		/// <param name="name">The cookie name.</param>
+		/// <param name="value">The cookie value.</param>
+		/// <param name="path">The path.</param>
+		/// <param name="expireDateTime">The expiration date time.</param>
+		/// <param name="domain">The cookie domain.</param>
+		/// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
+		void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
 
         /// <summary>
         /// Clear all browser cookies
         /// </summary>
         void ClearCookies();
+
+		/// <summary>
+		/// Clears the URL.
+		/// </summary>
+		void ClearUrl();
 
         /// <summary>
         /// Closes this instance.

--- a/src/SpecBind/Configuration/ApplicationConfigurationElement.cs
+++ b/src/SpecBind/Configuration/ApplicationConfigurationElement.cs
@@ -12,7 +12,7 @@ namespace SpecBind.Configuration
 	{
 		private const string StartUrlElement = @"startUrl";
 		private const string ExcludedAssembliesElement = @"excludedAssemblies";
-		private const string ActionRetryLimitElement = @"actionRetryLimit";
+		private const string RetryValidationUntilTimeoutElement = @"retryValidationUntilTimeout";
 		private const string WaitForStillElementBeforeClickingElement = @"waitForStillElementBeforeClicking";
 
 		/// <summary>
@@ -34,24 +34,20 @@ namespace SpecBind.Configuration
 		}
 
 		/// <summary>
-		/// Gets or sets the application's retry limit for actions in steps (defaults to 0).
+		/// Gets or sets a value indicating whether or not validation actions should retry until the standard ElementLocateTimeout.
 		/// </summary>
-		/// <value>The retry limit.</value>
-		/// <remarks>
-		/// Waits for 1 second between retries.
-		/// Experimental; use for working around general async flakiness.
-		/// </remarks>
-		[ConfigurationProperty(ActionRetryLimitElement, DefaultValue = 0, IsRequired = false)]
-		public int ActionRetryLimit
+		/// <value>whether or not to retry.</value>
+		[ConfigurationProperty(RetryValidationUntilTimeoutElement, DefaultValue = false, IsRequired = false)]
+		public bool RetryValidationUntilTimeout
 		{
 			get
 			{
-				return (int)this[ActionRetryLimitElement];
+				return (bool)this[RetryValidationUntilTimeoutElement];
 			}
 
 			set
 			{
-				this[ActionRetryLimitElement] = value;
+				this[RetryValidationUntilTimeoutElement] = value;
 			}
 		}
 
@@ -60,7 +56,7 @@ namespace SpecBind.Configuration
 		/// </summary>
 		/// <value>Whether or not to wait.</value>
 		/// <remarks>
-		/// Waits 200 milliseconds between element position measures.
+		/// Waits 200ms between element position measures.
 		/// Resolves issues where animation moves a button for a while, when it first becomes available.
 		/// Without this workaround, the click simply ends up sent to a nearby element or the page, usually doing nothing
 		/// and causing the next step verifying navigation or other click effect to timeout.

--- a/src/SpecBind/Configuration/BrowserFactoryConfigurationElement.cs
+++ b/src/SpecBind/Configuration/BrowserFactoryConfigurationElement.cs
@@ -19,6 +19,7 @@ namespace SpecBind.Configuration
         private const string SettingsElementName = "settings";
         private const string ReuseBrowserElementName = "reuseBrowser";
         private const string ValidateWebDriverElementName = "validateWebDriver";
+		private const string WaitForPendingAjaxCallsViaElementName = "waitForPendingAjaxCallsVia";
 
 
         /// <summary>
@@ -157,5 +158,24 @@ namespace SpecBind.Configuration
                 this[ValidateWebDriverElementName] = value;
             }
         }
+
+
+		/// <summary>
+		/// Gets or sets a value indicating what mechanism, if any,
+		/// to use to check for pending AJAX requests before proceeding with each step.
+		/// </summary>
+		[ConfigurationProperty(WaitForPendingAjaxCallsViaElementName, DefaultValue = "none", IsRequired = false)]
+		public string WaitForPendingAjaxCallsVia
+		{
+			get
+			{
+				return (string)this[WaitForPendingAjaxCallsViaElementName];
+			}
+
+			set
+			{
+				this[WaitForPendingAjaxCallsViaElementName] = value;
+			}
+		}
     }
 }

--- a/src/SpecBind/Helpers/IScenarioContextHelper.cs
+++ b/src/SpecBind/Helpers/IScenarioContextHelper.cs
@@ -25,6 +25,12 @@ namespace SpecBind.Helpers
         /// <returns>The exception if it exists; otherwise <c>null</c>.</returns>
         Exception GetError();
 
+		/// <summary>
+		/// Gets the text of the currently executing step.
+		/// </summary>
+		/// <returns>The step text.</returns>
+		string GetCurrentStepText();
+
         /// <summary>
         /// Gets the name of the step file.
         /// </summary>

--- a/src/SpecBind/Helpers/ScenarioContextHelper.cs
+++ b/src/SpecBind/Helpers/ScenarioContextHelper.cs
@@ -4,25 +4,26 @@
 
 namespace SpecBind.Helpers
 {
-    using TechTalk.SpecFlow;
+	using System;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Linq;
+	using System.Text;
+	using TechTalk.SpecFlow;
+	using TechTalk.SpecFlow.Tracing;
 
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using TechTalk.SpecFlow.Tracing;
-
-    /// <summary>
-    /// A helper class to abstract the scenario context.
-    /// </summary>
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class ScenarioContextHelper : IScenarioContextHelper
-    {
+	/// <summary>
+	/// A helper class to abstract the scenario context.
+	/// </summary>
+	[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	public class ScenarioContextHelper : IScenarioContextHelper
+	{
         private readonly ScenarioContext scenarioContext;
 
         private readonly FeatureContext featureContext;
 
-        /// <summary>
+		/// <summary>
         /// Constructs the context helper in a thread-safe manner.
         /// </summary>
         /// <param name="scenarioContext">The current scenario context.</param>
@@ -34,22 +35,97 @@ namespace SpecBind.Helpers
         }
 
         /// <summary>
-        /// Determines whether the current scenario contains the specified tag.
-        /// </summary>
-        /// <param name="tag">The tag.</param>
-        /// <returns>
-        ///   <c>true</c> the current scenario contains the specified tag; otherwise, <c>false</c>.
-        /// </returns>
-        public bool ContainsTag(string tag)
-        {
+		/// Determines whether the current scenario contains the specified tag.
+		/// </summary>
+		/// <param name="tag">The tag.</param>
+		/// <returns>
+		///   <c>true</c> the current scenario contains the specified tag; otherwise, <c>false</c>.
+		/// </returns>
+		public bool ContainsTag(string tag)
+		{
             return this.scenarioContext != null && FindTag(this.scenarioContext.ScenarioInfo.Tags, tag);
-        }
+		}
+
+        /// <summary>
+		/// Gets the text of the currently executing step.
+		/// </summary>
+		/// <remarks>
+		/// Logic provided by Gaspar Nagy on StackOverflow
+		/// </remarks>
+		/// <returns>The step text.</returns>
+		public string GetCurrentStepText()
+		{
+			int currentPositionText = 0;
+			try
+			{
+				var frames = new StackTrace(true).GetFrames();
+				if (frames != null)
+				{
+					var featureFileFrame = frames.FirstOrDefault(f =>
+																 f.GetFileName() != null &&
+																 f.GetFileName().EndsWith(".feature"));
+
+					if (featureFileFrame != null)
+					{
+						var lines = File.ReadAllLines(featureFileFrame.GetFileName());
+						const int frameSize = 20;
+						int currentLine = featureFileFrame.GetFileLineNumber() - 1;
+						int minLine = Math.Max(0, currentLine - frameSize);
+						int maxLine = Math.Min(lines.Length - 1, currentLine + frameSize);
+
+						for (int lineNo = currentLine - 1; lineNo >= minLine; lineNo--)
+						{
+							if (lines[lineNo].TrimStart().StartsWith("Scenario:"))
+							{
+								minLine = lineNo + 1;
+								break;
+							}
+						}
+
+						for (int lineNo = currentLine + 1; lineNo <= maxLine; lineNo++)
+						{
+							if (lines[lineNo].TrimStart().StartsWith("Scenario:"))
+							{
+								maxLine = lineNo - 1;
+								break;
+							}
+						}
+
+						for (int lineNo = minLine; lineNo <= maxLine; lineNo++)
+						{
+							if (lineNo == currentLine)
+							{
+								currentPositionText = lineNo - minLine;
+								var result = new StringBuilder(lines[lineNo]);
+								for (int i = lineNo + 1; i < lines.Length; i++)
+								{
+									if (!lines[i].TrimStart().StartsWith("|"))
+									{
+										break;
+									}
+
+									result.AppendLine();
+									result.Append(lines[i]);
+								}
+
+								return result.ToString();
+							}
+						}
+					}
+				}
+			}
+			catch (Exception)
+			{
+			}
+
+			return "(Unable to detect current step)";
+		}
 
         /// <summary>
         /// Gets the name of the step file.
         /// </summary>
         /// <returns>A unique file name for the scenario.</returns>
-        public string GetStepFileName()
+	    public string GetStepFileName()
         {
             return string.Format(
                 "error_{0}_{1}_{2}",
@@ -62,17 +138,17 @@ namespace SpecBind.Helpers
                 DateTime.Now.ToString("yyyyMMdd_HHmmss"));
         }
 
-        /// <summary>
-        /// Determines whether the current scenario's feature contains the specified tag.
-        /// </summary>
-        /// <param name="tag">The tag.</param>
-        /// <returns>
-        ///   <c>true</c> the current feature contains the specified tag; otherwise, <c>false</c>.
-        /// </returns>
-        public bool FeatureContainsTag(string tag)
-        {
+	    /// <summary>
+		/// Determines whether the current scenario's feature contains the specified tag.
+		/// </summary>
+		/// <param name="tag">The tag.</param>
+		/// <returns>
+		///   <c>true</c> the current feature contains the specified tag; otherwise, <c>false</c>.
+		/// </returns>
+		public bool FeatureContainsTag(string tag)
+		{
             return this.featureContext != null && FindTag(this.featureContext.FeatureInfo.Tags, tag);
-        }
+		}
 
         /// <summary>
         /// Gets the error.
@@ -83,45 +159,45 @@ namespace SpecBind.Helpers
             return this.scenarioContext != null ? this.scenarioContext.TestError : null;
         }
 
-        /// <summary>
-        /// Sets the value.
-        /// </summary>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        /// <param name="key">The key.</param>
-        /// <returns>The value if located.</returns>
-        public T GetValue<T>(string key)
-        {
-            try
-            {
+		/// <summary>
+		/// Sets the value.
+		/// </summary>
+		/// <typeparam name="T">The type of the value.</typeparam>
+		/// <param name="key">The key.</param>
+		/// <returns>The value if located.</returns>
+		public T GetValue<T>(string key)
+		{
+			try
+			{
                 return this.scenarioContext.Get<T>(key);
-            }
-            catch (KeyNotFoundException)
-            {
-                return default(T);
-            }
-        }
+			}
+			catch (KeyNotFoundException)
+			{
+				return default(T);
+			}
+		}
 
 
-        /// <summary>
-        /// Sets the value.
-        /// </summary>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        /// <param name="value">The value.</param>
-        /// <param name="key">The key.</param>
-        public void SetValue<T>(T value, string key)
-        {
+		/// <summary>
+		/// Sets the value.
+		/// </summary>
+		/// <typeparam name="T">The type of the value.</typeparam>
+		/// <param name="value">The value.</param>
+		/// <param name="key">The key.</param>
+		public void SetValue<T>(T value, string key)
+		{
             this.scenarioContext.Set(value, key);
-        }
+		}
 
-        /// <summary>
-        /// Determines whether the specified tags contains the given tag.
-        /// </summary>
-        /// <param name="tags">The tags collection.</param>
-        /// <param name="searchTag">The search tag.</param>
-        /// <returns><c>true</c> if the specified tags contains the given tag; otherwise, <c>false</c>.</returns>
-        private static bool FindTag(IEnumerable<string> tags, string searchTag)
-        {
-            return tags != null && tags.Any(t => string.Equals(t, searchTag, StringComparison.InvariantCultureIgnoreCase));
-        }
-    }
+		/// <summary>
+		/// Determines whether the specified tags contains the given tag.
+		/// </summary>
+		/// <param name="tags">The tags collection.</param>
+		/// <param name="searchTag">The search tag.</param>
+		/// <returns><c>true</c> if the specified tags contains the given tag; otherwise, <c>false</c>.</returns>
+		private static bool FindTag(IEnumerable<string> tags, string searchTag)
+		{
+			return tags != null && tags.Any(t => string.Equals(t, searchTag, StringComparison.InvariantCultureIgnoreCase));
+		}
+	}
 }

--- a/src/SpecBind/Helpers/Waiter.cs
+++ b/src/SpecBind/Helpers/Waiter.cs
@@ -1,0 +1,149 @@
+﻿// <copyright file="Waiter.cs">
+//    Copyright © 2013 Dan Piessens  All rights reserved.
+// </copyright>
+
+namespace SpecBind.Helpers
+{
+	using System;
+
+	/// <summary>
+	/// Provides a handy wait helper when you need to wait until a condition is met.
+	/// </summary>
+	public class Waiter
+	{
+		/// <summary>
+		/// Creates a waiter with default timeout and waitInterval.
+		/// </summary>
+		public Waiter()
+			: this(timeout: TimeSpan.FromSeconds(30), waitInterval: TimeSpan.FromMilliseconds(200))
+		{
+		}
+
+		/// <summary>
+		/// Creates a waiter with the specified timeout and default waitInterval.
+		/// </summary>
+		/// <param name="timeout">The duration after which to stop waiting.</param>
+		public Waiter(TimeSpan timeout)
+			: this(timeout: timeout, waitInterval: TimeSpan.FromMilliseconds(200))
+		{
+		}
+
+		/// <summary>
+		/// Creates a waiter with the specified timeout and waitInterval.
+		/// </summary>
+		/// <param name="timeout">The duration after which to stop waiting.</param>
+		/// <param name="waitInterval">The length of time to wait between retries.</param>
+		public Waiter(TimeSpan timeout, TimeSpan waitInterval)
+		{
+			this.Timeout = timeout;
+			this.WaitInterval = waitInterval;
+		}
+
+		/// <summary>
+		/// Gets or sets the Timeout.
+		/// </summary>
+		public TimeSpan Timeout { get; protected set; }
+
+		/// <summary>
+		/// Gets or sets the WaitInterval.
+		/// </summary>
+		public TimeSpan WaitInterval { get; protected set; }
+
+		/// <summary>
+		/// Waits for the given condition function to return true, or until the timeout is reached.
+		/// </summary>
+		/// <param name="conditionChecker">The condition function to check.</param>
+		/// <exception cref="TimeoutException">The condition was not met before the timeout was reached.</exception>
+		public void WaitFor(Func<bool> conditionChecker)
+		{
+			var startTime = DateTime.Now;
+			var waitIntervalMilliseconds = Convert.ToInt32(this.WaitInterval.TotalMilliseconds);
+
+			// TODO: Use Task.Run to put this on a background thread?
+			// Is there any benefit it that, since we still have to wait for it?
+			do
+			{
+				if (conditionChecker())
+				{
+					return;
+				}
+
+				System.Threading.Thread.Sleep(waitIntervalMilliseconds);
+			}
+			while (DateTime.Now - startTime < this.Timeout);
+
+			throw new TimeoutException("Timed out after " + this.Timeout);
+		}
+	}
+
+	/// <summary>
+	/// Provides a handy wait helper when you need to wait until a condition is met.
+	/// </summary>
+	/// <typeparam name="T">The type of the element being waited for.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "SA1402", Justification = "Generic and Non-generic versions of same class")]
+	public class Waiter<T>
+	{
+		/// <summary>
+		/// Creates a waiter with default timeout and waitInterval.
+		/// </summary>
+		public Waiter() : this(timeout: TimeSpan.FromSeconds(30), waitInterval: TimeSpan.FromMilliseconds(200))
+		{
+		}
+
+		/// <summary>
+		/// Creates a waiter with the specified timeout and default waitInterval.
+		/// </summary>
+		/// <param name="timeout">The duration after which to stop waiting.</param>
+		public Waiter(TimeSpan timeout) : this(timeout: timeout, waitInterval: TimeSpan.FromMilliseconds(200))
+		{
+		}
+
+		/// <summary>
+		/// Creates a waiter with the specified timeout and waitInterval.
+		/// </summary>
+		/// <param name="timeout">The duration after which to stop waiting.</param>
+		/// <param name="waitInterval">The length of time to wait between retries.</param>
+		public Waiter(TimeSpan timeout, TimeSpan waitInterval)
+		{
+			this.Timeout = timeout;
+			this.WaitInterval = waitInterval;
+		}
+
+		/// <summary>
+		/// Gets or sets the Timeout.
+		/// </summary>
+		public TimeSpan Timeout { get; protected set; }
+
+		/// <summary>
+		/// Gets or sets the WaitInterval.
+		/// </summary>
+		public TimeSpan WaitInterval { get; protected set; }
+
+		/// <summary>
+		/// Waits for the given condition function to return true, or until the timeout is reached.
+		/// </summary>
+		/// <param name="element">The object being checked, to pass to the condition function.</param>
+		/// <param name="conditionChecker">The condition function to check.</param>
+		/// <exception cref="TimeoutException">The condition was not met before the timeout was reached.</exception>
+		public void WaitFor(T element, Func<T, bool> conditionChecker)
+		{
+			var startTime = DateTime.Now;
+			var waitIntervalMilliseconds = Convert.ToInt32(this.WaitInterval.TotalMilliseconds);
+
+			// TODO: Use Task.Run to put this on a background thread?
+			// Is there any benefit it that, since we still have to wait for it?
+			do
+			{
+				if (conditionChecker(element))
+				{
+					return;
+				}
+
+				System.Threading.Thread.Sleep(waitIntervalMilliseconds);
+			}
+			while (DateTime.Now - startTime < this.Timeout);
+
+			throw new TimeoutException("Timed out after " + this.Timeout);
+		}
+	}
+}

--- a/src/SpecBind/SpecBind.csproj
+++ b/src/SpecBind/SpecBind.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Actions\SetCookiePreAction.cs" />
     <Compile Include="Actions\SetTokenFromValueAction.cs" />
     <Compile Include="Actions\HighlightLocatorAction.cs" />
+    <Compile Include="Actions\ValidateActionBase.cs" />
     <Compile Include="Actions\ValidateElementEnabledAction.cs" />
     <Compile Include="Actions\ValidateElementExistsAction.cs" />
     <Compile Include="Actions\ValidateItemAction.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="Helpers\TableItemType.cs" />
     <Compile Include="Helpers\TokenManager.cs" />
     <Compile Include="Helpers\ValidationTableExtensions.cs" />
+    <Compile Include="Helpers\Waiter.cs" />
     <Compile Include="Helpers\WrappedSettingHelper.cs" />
     <Compile Include="PageStepBase.cs" />
     <Compile Include="Pages\ElementDescription.cs" />

--- a/src/SpecBind/WaitingSteps.cs
+++ b/src/SpecBind/WaitingSteps.cs
@@ -7,6 +7,7 @@ namespace SpecBind
 
     using SpecBind.ActionPipeline;
     using SpecBind.Actions;
+	using SpecBind.BrowserSupport;
     using SpecBind.Helpers;
 
     using TechTalk.SpecFlow;
@@ -39,6 +40,8 @@ namespace SpecBind
         private const string WaitForListElementToContainItemsRegex = @"I wait for (.+) to contain items";
         private const string WaitForListElementToContainItemsWithTimeoutRegex = @"I wait (\d+) seconds? for (.+) to contain items";
         private const string WaitForActiveViewRegex = @"I wait for the view to become active";
+		private const string WaitForAngularRegex = @"I wait for (?i)angular ajax(?-i) calls to complete";
+		private const string WaitForjQueryRegex = @"I wait for (?i)jquery ajax(?-i) calls to complete";
 
         // The following Regex items are for the given "past tense" form
         private const string GivenWaitToSeeElementRegex = @"I waited to see (.+)";
@@ -54,6 +57,8 @@ namespace SpecBind
         private const string GivenWaitForListElementToContainItemsRegex = @"I waited for (.+) to contain items";
         private const string GivenWaitForListElementToContainItemsWithTimeoutRegex = @"I waited (\d+) seconds? for (.+) to contain items";
         private const string GivenWaitForActiveViewRegex = @"I waited for the view to become active";
+		private const string GivenWaitForAngularRegex = @"I waited for (?i)angular ajax(?-i) calls to complete";
+		private const string GivenWaitForjQueryRegex = @"I waited for (?i)jquery ajax(?-i) calls to complete";
 
         private readonly IActionPipelineService actionPipelineService;
 
@@ -338,7 +343,29 @@ namespace SpecBind
             page.WaitForPageToBeActive();
         }
 
-        /// <summary>
+		/// <summary>
+		/// A step that waits for any pending Angular AJAX calls to complete.
+		/// </summary>
+		[Given(GivenWaitForAngularRegex)]
+		[When(WaitForAngularRegex)]
+		[Then(WaitForAngularRegex)]
+		public void WaitForAngular()
+		{
+			WebDriverSupport.WaitForAngular();
+		}
+
+		/// <summary>
+		/// A step that waits for any pending jQuery AJAX calls to complete.
+		/// </summary>
+		[Given(GivenWaitForjQueryRegex)]
+		[When(WaitForjQueryRegex)]
+		[Then(WaitForjQueryRegex)]
+		public void WaitForjQuery()
+		{
+			WebDriverSupport.WaitForjQuery();
+		}
+
+		/// <summary>
         /// Gets the time span from the seconds value.
         /// </summary>
         /// <param name="seconds">The seconds.</param>


### PR DESCRIPTION
* Added browserFactory configuration attribute waitForPendingAjaxCallsVia.  Recognized values are angular and jQuery (case-insensitive).  If set, will implicitly wait until pending Ajax calls are complete after every step.

* Added Gherkin steps to wait for angular or jQuery, as an alternative to implicitly waiting after every step via config file setting.

* Removed experimental application configuration attribute ActionRetryLimit.  Wasn't helpful.

* Added application configuration attribute RetryValidationUntilTimeout (defaults to false).  Helps in odd timing cases where browser seems to be updating the DOM.  Helps in cases where you are checking for a particular number of items in a list, or that list number X has certain values.  Added because it seems to be a race condition between the test and the browser's foreground thread -- i.e. outside of pending Ajax calls.

* Added diagnostic output of the Gherkin to the console when running in debug mode.  Includes messages where it's waiting or retrying.

* Cleaned up issues with Dispose() logic in BrowserBase and SeleniumBrowser that need to dispose the driver.  Also removed the "true" flag (to dispose) when registering the browser with the IoC container, as it interfered with the reuseBrowser option.  The corrected Dispose() logic should remove the need for that.
