### PR TITLE
Allow users to access cookies via 'GetCookie' on the BrowserBase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ UpgradeLog*.XML
 /src/lib
 src/SpecBind.sln.DotSettings
 examples/FullDemo/ContosoUniversity/App_Data/School.sdf
+/examples/FullDemo/ContosoUniversity/Properties/PublishProfiles/ContosoUniversity.pubxml

--- a/src/SpecBind.CodedUI.Tests/CookieBuilderFixture.cs
+++ b/src/SpecBind.CodedUI.Tests/CookieBuilderFixture.cs
@@ -4,6 +4,7 @@
 namespace SpecBind.CodedUI.Tests
 {
     using System;
+    using System.Text.RegularExpressions;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -129,6 +130,20 @@ namespace SpecBind.CodedUI.Tests
             var cookieString = CookieBuilder.CreateCookie("TestCookie", "Some Value", "/MyPath", new DateTime(2015, 3, 30, 0, 0, 0, 0, DateTimeKind.Utc), "www.mydomain.com", false);
 
             Assert.AreEqual(@"document.cookie = ""TestCookie=Some%20Value; expires=Mon, 30 Mar 2015 00:00:00 GMT; domain=www.mydomain.com; path=/MyPath""", cookieString);
+        }
+
+        [TestMethod]
+        public void TestGetCookieValueCreatesAndCallsFunction()
+        {
+            var cookieString = CookieBuilder.GetCookieValue("TestCookie");
+            var strippedString = Regex.Replace(cookieString, @"\s+", "");
+            var expectedOutput = "function getCookie(name) {\n" + "  var value = \"; \" + document.cookie;\n"
+                                 + "  var parts = value.split(\"; \" + name + \"=\");\n"
+                                 + "  if (parts.length == 2) return parts.pop().split(\";\").shift();\n" + "}\n"
+                                 + "getCookie('TestCookie')";
+            var strippedOutput = Regex.Replace(expectedOutput, @"\s+", "");
+
+            Assert.AreEqual(strippedOutput, strippedString);
         }
     }
 }

--- a/src/SpecBind.CodedUI/CookieBuilder.cs
+++ b/src/SpecBind.CodedUI/CookieBuilder.cs
@@ -79,6 +79,25 @@ namespace SpecBind.CodedUI
         }
 
         /// <summary>
+        /// Gets the value of a cookie via javascript's document
+        /// </summary>
+        /// <param name="name">The name of the cookie to retrieve</param>
+        public static string GetCookieValue(string name)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine(
+                "function getCookie(name) {\n" +
+                "  var value = \"; \" + document.cookie;\n" +
+                "  var parts = value.split(\"; \" + name + \"=\");\n" +
+                "  if (parts.length == 2) return parts.pop().split(\";\").shift();\n" +
+                "}\n");
+
+            builder.AppendFormat("getCookie('{0}')", name);
+
+            return builder.ToString();
+        }
+
+        /// <summary>
         /// Strips the port from the domain.
         /// </summary>
         /// <param name="domain">The domain.</param>

--- a/src/SpecBind.Selenium.Tests/SeleniumBrowserFixture.cs
+++ b/src/SpecBind.Selenium.Tests/SeleniumBrowserFixture.cs
@@ -169,6 +169,61 @@ namespace SpecBind.Selenium.Tests
 		}
 
 		/// <summary>
+		/// Tests the GetCookie method returns a System.Net.Cookie
+		/// </summary>
+		[TestMethod]
+		public void TestGetCookieReturnsCookieWhenExists()
+		{
+			const string CookieName = "TestCookie";
+			const string CookieValue = "SomeValue";
+			System.Net.Cookie cookie = null;
+			var cookies = new Mock<ICookieJar>(MockBehavior.Strict);
+			cookies.Setup(c => c.GetCookieNamed(CookieName)).Returns(new Cookie(CookieName, CookieValue));
+
+			var options = new Mock<IOptions>(MockBehavior.Strict);
+			options.Setup(o => o.Cookies).Returns(cookies.Object);
+
+			var driver = this.CreateMockWebDriverExpectingInitialization();
+			driver.Setup(d => d.Manage()).Returns(options.Object);
+
+			this.TestBrowserWith(driver, browser =>
+			{
+				cookie = browser.GetCookie(CookieName);
+			});
+
+			options.VerifyAll();
+			cookies.VerifyAll();
+			Assert.AreEqual(CookieName, cookie.Name);
+			Assert.AreEqual(CookieValue, cookie.Value);
+		}
+
+		/// <summary>
+		/// Tests the GetCookie method returns null when a cookie with a given name was not found
+		/// </summary>
+		[TestMethod]
+		public void TestGetCookieReturnsNullWhenCookieDoesNotExist()
+		{
+			System.Net.Cookie cookie = null;
+			var cookies = new Mock<ICookieJar>(MockBehavior.Strict);
+			cookies.Setup(c => c.GetCookieNamed(It.IsAny<string>())).Returns(null as Cookie);
+
+			var options = new Mock<IOptions>(MockBehavior.Strict);
+			options.Setup(o => o.Cookies).Returns(cookies.Object);
+
+			var driver = this.CreateMockWebDriverExpectingInitialization();
+			driver.Setup(d => d.Manage()).Returns(options.Object);
+
+			this.TestBrowserWith(driver, browser =>
+			{
+				cookie = browser.GetCookie("not a cookie");
+			});
+
+			options.VerifyAll();
+			cookies.VerifyAll();
+			Assert.IsNull(cookie);
+		}
+
+		/// <summary>
 		/// Tests the clear URL method.
 		/// </summary>
 		[TestMethod]

--- a/src/SpecBind/BrowserSupport/BrowserBase.cs
+++ b/src/SpecBind/BrowserSupport/BrowserBase.cs
@@ -4,18 +4,19 @@
 
 namespace SpecBind.BrowserSupport
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Linq;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
 
-	using SpecBind.Actions;
-	using SpecBind.Pages;
-	using UriHelper = Helpers.UriHelper;
+    using SpecBind.Actions;
+    using SpecBind.Pages;
+    using UriHelper = Helpers.UriHelper;
 
-	/// <summary>
-	/// A set of extension methods for the <see cref="IBrowser" /> interface.
-	/// </summary>
-	public abstract class BrowserBase : IBrowser
+    /// <summary>
+    /// A set of extension methods for the <see cref="IBrowser" /> interface.
+    /// </summary>
+    public abstract class BrowserBase : IBrowser
     {
         private readonly ILogger logger;
         private bool disposed;
@@ -43,49 +44,56 @@ namespace SpecBind.BrowserSupport
         /// </value>
         public abstract string Url { get; }
 
-		/// <summary>
-		/// Gets a value indicating whether or not the browser has been closed.
-		/// </summary>
-		public bool IsClosed { get; private set; }
+        /// <summary>
+        /// Gets a value indicating whether or not the browser has been closed.
+        /// </summary>
+        public bool IsClosed { get; private set; }
 
-		/// <summary>
-		/// Gets a value indicating whether this instance is disposed.
-		/// </summary>
-		/// <value>
-		/// <c>true</c> if this instance is disposed; otherwise, <c>false</c>.
-		/// </value>
-		public bool IsDisposed
+        /// <summary>
+        /// Gets a value indicating whether this instance is disposed.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is disposed; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDisposed
         {
             get { return this.disposed; }
         }
 
-		/// <summary>
-		/// Adds the cookie to the browser.
-		/// </summary>
-		/// <param name="name">The cookie name.</param>
-		/// <param name="value">The cookie value.</param>
-		/// <param name="path">The path.</param>
-		/// <param name="expireDateTime">The expiration date time.</param>
-		/// <param name="domain">The cookie domain.</param>
-		/// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
-		public abstract void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
+        /// <summary>
+        /// Adds the cookie to the browser.
+        /// </summary>
+        /// <param name="name">The cookie name.</param>
+        /// <param name="value">The cookie value.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="expireDateTime">The expiration date time.</param>
+        /// <param name="domain">The cookie domain.</param>
+        /// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
+        public abstract void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
+
+        /// <summary>
+        /// Get a cookie from the browser
+        /// </summary>
+        /// <param name="name">The name of the cookie</param>
+        /// <returns>The cookie (if exists)</returns>
+        public abstract Cookie GetCookie(string name);
 
         /// <summary>
         /// Clear all browser cookies
         /// </summary>
         public abstract void ClearCookies();
 
-		/// <summary>
-		/// Clears the URL.
-		/// </summary>
-		public abstract void ClearUrl();
+        /// <summary>
+        /// Clears the URL.
+        /// </summary>
+        public abstract void ClearUrl();
 
         /// <summary>
         /// Closes this instance.
         /// </summary>
         public abstract void Close();
 
-		/// <summary>
+        /// <summary>
         /// Closes the instance and optionally dispose of all resources
         /// </summary>
         /// <param name="dispose">Whether or not resources should get disposed</param>
@@ -98,7 +106,7 @@ namespace SpecBind.BrowserSupport
                 this.Dispose();
             }
 
-			this.IsClosed = true;
+            this.IsClosed = true;
         }
 
         /// <summary>
@@ -270,10 +278,10 @@ namespace SpecBind.BrowserSupport
         /// <returns>A page interface.</returns>
         protected abstract IPage CreateNativePage(Type pageType, bool verifyPageValidity);
 
-		/// <summary>
-		/// Releases windows and driver specific resources. This method is already protected by the base instance.
-		/// </summary>
-		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-		protected abstract void DisposeWindow(bool disposing);
+        /// <summary>
+        /// Releases windows and driver specific resources. This method is already protected by the base instance.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected abstract void DisposeWindow(bool disposing);
     }
 }

--- a/src/SpecBind/BrowserSupport/IBrowser.cs
+++ b/src/SpecBind/BrowserSupport/IBrowser.cs
@@ -4,15 +4,16 @@
 
 namespace SpecBind.BrowserSupport
 {
-	using System;
-	using System.Collections.Generic;
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
 
-	using SpecBind.Pages;
+    using SpecBind.Pages;
 
-	/// <summary>
-	/// An interface to describe browser methods.
-	/// </summary>
-	public interface IBrowser : IDisposable
+    /// <summary>
+    /// An interface to describe browser methods.
+    /// </summary>
+    public interface IBrowser : IDisposable
     {
         /// <summary>
         /// Gets the type of the base page.
@@ -28,38 +29,45 @@ namespace SpecBind.BrowserSupport
         /// <value>
         /// The url of the base page.
         /// </value>
-		string Url { get; }
+        string Url { get; }
 
-		/// <summary>
-		/// Gets a value indicating whether or not the browser has been closed.
-		/// </summary>
-		bool IsClosed { get; }
+        /// <summary>
+        /// Gets a value indicating whether or not the browser has been closed.
+        /// </summary>
+        bool IsClosed { get; }
 
-		/// <summary>
-		/// Gets a value indicating whether or not the browser has been disposed.
-		/// </summary>
-		bool IsDisposed { get; }
+        /// <summary>
+        /// Gets a value indicating whether or not the browser has been disposed.
+        /// </summary>
+        bool IsDisposed { get; }
 
-		/// <summary>
-		/// Adds the cookie to the browser.
-		/// </summary>
-		/// <param name="name">The cookie name.</param>
-		/// <param name="value">The cookie value.</param>
-		/// <param name="path">The path.</param>
-		/// <param name="expireDateTime">The expiration date time.</param>
-		/// <param name="domain">The cookie domain.</param>
-		/// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
-		void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
+        /// <summary>
+        /// Adds the cookie to the browser.
+        /// </summary>
+        /// <param name="name">The cookie name.</param>
+        /// <param name="value">The cookie value.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="expireDateTime">The expiration date time.</param>
+        /// <param name="domain">The cookie domain.</param>
+        /// <param name="secure">if set to <c>true</c> the cookie is secure.</param>
+        void AddCookie(string name, string value, string path, DateTime? expireDateTime, string domain, bool secure);
+
+        /// <summary>
+        /// Get a cookie from the browser
+        /// </summary>
+        /// <param name="name">The name of the cookie</param>
+        /// <returns>The cookie (if exists)</returns>
+        Cookie GetCookie(string name);
 
         /// <summary>
         /// Clear all browser cookies
         /// </summary>
         void ClearCookies();
 
-		/// <summary>
-		/// Clears the URL.
-		/// </summary>
-		void ClearUrl();
+        /// <summary>
+        /// Clears the URL.
+        /// </summary>
+        void ClearUrl();
 
         /// <summary>
         /// Closes this instance.


### PR DESCRIPTION
I added a method called `GetCookie` to IBrowser. Both Selenium and CodedUI have implementations, although via CodedUI I was only able to retrieve the value of a cookie, while I was able to retrieve more properties via Selenium (such as Expiration).

I then added the current browser to the scenario context in WebDriverSupport by doing the following:

    ScenarioContext.Current.Set(Browser, "CurrentBrowser");

Now, users of SpecBind will be able to get the browser off of the scenario context, and call its public methods such as `GetCookie`. This is useful for testing scenarios where you need to validate various cookies exist after interacting with different pages/page elements.

Let me know if there are any questions or concerns with this. Thanks!