### PR TITLE
Issue #153 Enabled/Disables validation rule updates

### DIFF
--- a/src/SpecBind.Tests/SpecBind.Tests.csproj
+++ b/src/SpecBind.Tests/SpecBind.Tests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Validation\ItemValidationHelper.cs" />
     <Compile Include="Validation\LessThanComparerFixture.cs" />
     <Compile Include="Validation\LessThanEqualsComparerFixture.cs" />
+    <Compile Include="Validation\NotEnabledComparerFixture.cs" />
     <Compile Include="Validation\NotEqualsComparerFixture.cs" />
     <Compile Include="Validation\StartsWithComparerFixture.cs" />
     <Compile Include="Validation\ValidationTablePreActionFixture.cs" />

--- a/src/SpecBind.Tests/Validation/EnabledComparerFixture.cs
+++ b/src/SpecBind.Tests/Validation/EnabledComparerFixture.cs
@@ -46,24 +46,24 @@ namespace SpecBind.Tests.Validation
         /// Tests the compare method for simple comparisons.
         /// </summary>
         [TestMethod]
-        public void TestCompareExistsCase()
+        public void TestCompareEnabledCase()
         {
             var propertyData = new Mock<IPropertyData>(MockBehavior.Strict);
             propertyData.Setup(p => p.CheckElementEnabled()).Returns(true);
 
-            RunItemCompareTest("True", null, true, propertyData);
+            RunItemCompareTest(null, null, true, propertyData);
         }
 
         /// <summary>
         /// Tests the compare method for simple comparisons.
         /// </summary>
         [TestMethod]
-        public void TestCompareNotExistsCase()
+        public void TestCompareNotEnabledCase()
         {
             var propertyData = new Mock<IPropertyData>(MockBehavior.Strict);
             propertyData.Setup(p => p.CheckElementEnabled()).Returns(false);
 
-            RunItemCompareTest("False", null, true, propertyData);
+            RunItemCompareTest(null, null, false, propertyData);
         }
     }
 }

--- a/src/SpecBind.Tests/Validation/NotEnabledComparerFixture.cs
+++ b/src/SpecBind.Tests/Validation/NotEnabledComparerFixture.cs
@@ -1,0 +1,65 @@
+﻿namespace SpecBind.Tests.Validation
+{
+    using System.Linq;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Moq;
+
+    using SpecBind.Pages;
+    using SpecBind.Validation;
+
+    /// <summary>
+    /// A test fixture for the not enabled comparison.
+    /// </summary>
+    [TestClass]
+    public class NotEnabledComparerFixture : ComparisonTestBase<NotEnabledComparer>
+    {
+        /// <summary>
+        /// Tests the rule key property for the correct tags.
+        /// </summary>
+        [TestMethod]
+        public void TestRuleValuesReturnsProperTags()
+        {
+            var item = new NotEnabledComparer();
+
+            CollectionAssert.AreEquivalent(new[] { "notenabled", "isnotenabled", "disabled" }, item.RuleKeys.ToList());
+        }
+
+        /// <summary>
+        /// Tests the compare method for simple comparisons.
+        /// </summary>
+        [TestMethod]
+        public void TestCompareNotEnabledCase()
+        {
+            var propertyData = new Mock<IPropertyData>(MockBehavior.Strict);
+            propertyData.Setup(p => p.CheckElementEnabled()).Returns(false);
+
+            RunItemCompareTest(null, null, true, propertyData);
+        }
+
+        /// <summary>
+        /// Tests the compare method for simple comparisons.
+        /// </summary>
+        [TestMethod]
+        public void TestCompareEnabledCase()
+        {
+            var propertyData = new Mock<IPropertyData>(MockBehavior.Strict);
+            propertyData.Setup(p => p.CheckElementEnabled()).Returns(true);
+
+            RunItemCompareTest(null, null, false, propertyData);
+        }
+
+        /// <summary>
+        /// Tests the compare method for simple comparisons.
+        /// </summary>
+        [TestMethod]
+        public void TestCompareNotEnabledValueSetCaseShouldIgnoreValue()
+        {
+            var propertyData = new Mock<IPropertyData>(MockBehavior.Strict);
+            propertyData.Setup(p => p.CheckElementEnabled()).Returns(false);
+
+            RunItemCompareTest("False", null, true, propertyData);
+        }
+    }
+}

--- a/src/SpecBind/SpecBind.csproj
+++ b/src/SpecBind/SpecBind.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Validation\IValidationTable.cs" />
     <Compile Include="Validation\LessThanComparer.cs" />
     <Compile Include="Validation\LessThanEqualsComparer.cs" />
+    <Compile Include="Validation\NotEnabledComparer.cs" />
     <Compile Include="Validation\NotEqualsComparer.cs" />
     <Compile Include="Validation\StartsWithComparer.cs" />
     <Compile Include="Validation\ValidateTableHelpers.cs" />

--- a/src/SpecBind/Validation/EnabledComparer.cs
+++ b/src/SpecBind/Validation/EnabledComparer.cs
@@ -28,10 +28,8 @@ namespace SpecBind.Validation
         /// <returns><c>true</c> if the comparison passes, <c>false</c> otherwise.</returns>
         public override bool Compare(IPropertyData property, string expectedValue, string actualValue)
         {
-            bool parsedValue;
-            return (expectedValue != null && bool.TryParse(expectedValue, out parsedValue) && !parsedValue)
-                       ? !property.CheckElementEnabled()
-                       : property.CheckElementEnabled();
+            // Note: expected value is ignored when checking this
+            return property.CheckElementEnabled();
         }
     }
 }

--- a/src/SpecBind/Validation/EqualsComparer.cs
+++ b/src/SpecBind/Validation/EqualsComparer.cs
@@ -19,18 +19,6 @@ namespace SpecBind.Validation
         }
 
         /// <summary>
-        /// Gets a value indicating whether this instance is the default rule to use.
-        /// </summary>
-        /// <value><c>true</c> if this instance is a default rule; otherwise, <c>false</c>.</value>
-        public override bool IsDefault
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        /// <summary>
         /// Compares the string values according to the rule.
         /// </summary>
         /// <param name="expected">The expected value.</param>

--- a/src/SpecBind/Validation/IValidationComparer.cs
+++ b/src/SpecBind/Validation/IValidationComparer.cs
@@ -13,12 +13,6 @@ namespace SpecBind.Validation
     public interface IValidationComparer
     {
         /// <summary>
-        /// Gets a value indicating whether this instance is the default rule to use.
-        /// </summary>
-        /// <value><c>true</c> if this instance is a default rule; otherwise, <c>false</c>.</value>
-        bool IsDefault { get; }
-
-        /// <summary>
         /// Gets the rule keys.
         /// </summary>
         /// <value>The rule keys.</value>

--- a/src/SpecBind/Validation/NotEnabledComparer.cs
+++ b/src/SpecBind/Validation/NotEnabledComparer.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="NotEnabledComparer.cs">
+//    Copyright © 2013 Dan Piessens  All rights reserved.
+// </copyright>
+
+namespace SpecBind.Validation
+{
+    using SpecBind.Pages;
+
+    /// <summary>
+    /// A validation comparer to see if something is not enabled.
+    /// </summary>
+    public class NotEnabledComparer : ValidationComparerBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotEnabledComparer"/> class.
+        /// </summary>
+        public NotEnabledComparer()
+            : base("notenabled", "isnotenabled", "disabled")
+        {
+        }
+
+        /// <summary>
+        /// Compares the values using the specified property.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <param name="expectedValue">The expected value.</param>
+        /// <param name="actualValue">The actual value.</param>
+        /// <returns><c>true</c> if the comparison passes, <c>false</c> otherwise.</returns>
+        public override bool Compare(IPropertyData property, string expectedValue, string actualValue)
+        {
+            // Note: expected value is ignored when checking this
+            return !property.CheckElementEnabled();
+        }
+    }
+}

--- a/src/SpecBind/Validation/ValidationComparerBase.cs
+++ b/src/SpecBind/Validation/ValidationComparerBase.cs
@@ -21,18 +21,6 @@ namespace SpecBind.Validation
         }
 
         /// <summary>
-        /// Gets a value indicating whether this instance is the default rule to use.
-        /// </summary>
-        /// <value><c>true</c> if this instance is a default rule; otherwise, <c>false</c>.</value>
-        public virtual bool IsDefault
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether this validation requires a field value.
         /// </summary>
         /// <value><c>true</c> if a field value is required; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
Several changes were made in this PR

- Bad validation rules no longer default to "equals" but throw an error
- Pre Action pipeline errors will prevent action execution but run all pre-actions
- Not Enabled / Disabled / Is Not Enabled validation rule now exists
- Enabled and Disabled rules ignore any values passed to them